### PR TITLE
refactor KubernetesResourceHandler api

### DIFF
--- a/src/k8s_resource_handler/lightkube/__init__.py
+++ b/src/k8s_resource_handler/lightkube/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Utilities that extend the functionality of the Lightkube package."""


### PR DESCRIPTION
Changes KRH api from needing context/template_file factories to instead taking static values for context and template_files.  These inputs can be lazily loaded (a KRH object can be instantiated without defining them), allowing a user to create the object in a charm __init__ but later add context based on a hook's logic.