### PR TITLE
fix: delete_many passing incorrect arg to client

### DIFF
--- a/src/charmed_kubeflow_chisme/lightkube/batch/_many.py
+++ b/src/charmed_kubeflow_chisme/lightkube/batch/_many.py
@@ -94,4 +94,4 @@ def delete_many(
                 f" got {type(obj)}"
             )
 
-        client.delete(res=obj, name=obj.metadata.name, namespace=namespace)
+        client.delete(res=obj.__class__, name=obj.metadata.name, namespace=namespace)

--- a/tests/test_lightkube.py
+++ b/tests/test_lightkube.py
@@ -129,7 +129,7 @@ def test_delete_many(
     # Assert we called apply with the expected inputs
     calls = [None] * len(objects)
     for i, (obj, name, namespace) in enumerate(zip(objects, expected_names, expected_namespaces)):
-        calls[i] = mock.call(res=obj, name=name, namespace=namespace)
+        calls[i] = mock.call(res=obj.__class__, name=name, namespace=namespace)
     mocked_lightkube_client.delete.assert_has_calls(calls)
 
 


### PR DESCRIPTION
Client.delete() expects a resource type, not an instantiated resource.  This fix updates delete_many to