### PR TITLE
feat: add shared testing infrastructuve

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ both the Charmed Operators maintained by the [Charmed Kubeflow](ckf) team as wel
 * [Kubernetes](./src/charmed_kubeflow_chisme/kubernetes/README.md): Helpers for interacting with Kubernetes
 * [Lightkube](./src/charmed_kubeflow_chisme/lightkube/README.md): Helpers specific to using or extending [Lightkube](lightkube-rtd)
 * [Status Handling](./src/charmed_kubeflow_chisme/status_handling/README.md): Helpers for working with Charm Status objects
+* [Testing](./src/charmed_kubeflow_chisme/testing/README.md): Tools for unit or integration testing, such as importable and resusable tests.
 * [Types](./src/charmed_kubeflow_chisme/types/README.md): Reusable typing definitions, useful for adding type hints
 
 [ckf]: https://charmed-kubeflow.io/

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     jinja2
     lightkube > 0.10.0
     ops > 1.2.0
+    requests
 
 [options.extras_require]
 test =

--- a/src/charmed_kubeflow_chisme/testing/README.md
+++ b/src/charmed_kubeflow_chisme/testing/README.md
@@ -1,0 +1,24 @@
+# Status Handling
+
+Helpers for working with Charm Status objects
+
+# Contents
+
+## `get_first_worst_error`
+
+Parses a list of charm status objects, returning the "worst".  For example, in order of worst to best:
+* BlockedStatus
+* WaitingStatus
+* ActiveStatus
+
+Example usage:
+```python
+statuses = [
+    ActiveStatus(),
+    WaitingStatus("waiting"),
+    BlockedStatus("blocked1"),
+    BlockedStatus("blocked2")
+]
+worst = get_first_worst_error(statuses)
+# worst is "blocked1"
+```

--- a/src/charmed_kubeflow_chisme/testing/__init__.py
+++ b/src/charmed_kubeflow_chisme/testing/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tools for unit or integration testing, such as importable and resusable tests."""
+
+from ._observability import test_prometheus_grafana_integration
+
+__all__ = [
+    test_prometheus_grafana_integration,
+]

--- a/src/charmed_kubeflow_chisme/testing/__init__.py
+++ b/src/charmed_kubeflow_chisme/testing/__init__.py
@@ -3,8 +3,8 @@
 
 """Tools for unit or integration testing, such as importable and resusable tests."""
 
-from ._observability import test_prometheus_grafana_integration
+from ._observability import prometheus_grafana_integration_test
 
 __all__ = [
-    test_prometheus_grafana_integration,
+    prometheus_grafana_integration_test,
 ]

--- a/src/charmed_kubeflow_chisme/testing/_observability.py
+++ b/src/charmed_kubeflow_chisme/testing/_observability.py
@@ -1,3 +1,6 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 import logging
 import json
 import requests
@@ -46,7 +49,8 @@ async def prometheus_grafana_integration_test(application_name: str, ops_test):
     log.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
 
     r = requests.get(
-        f'http://{prometheus_unit_ip}:9090/api/v1/query?query=up{{juju_application="{application_name}"}}'
+        f'http://{prometheus_unit_ip}:9090/api/v1/query?query='
+        f'up{{juju_application="{application_name}"}}'
     )
     response = json.loads(r.content.decode("utf-8"))
     response_status = response["status"]

--- a/src/charmed_kubeflow_chisme/testing/_observability.py
+++ b/src/charmed_kubeflow_chisme/testing/_observability.py
@@ -6,7 +6,7 @@ import requests
 log = logging.getLogger(__name__)
 
 
-async def test_prometheus_grafana_integration(application_name: str, ops_test):
+async def prometheus_grafana_integration_test(application_name: str, ops_test):
     """Deploy prometheus, grafana and required relations, then test the metrics.
 
     TODO: Should grafana and prometheus be fixtures here, so they don't stay around?  Or should

--- a/src/charmed_kubeflow_chisme/testing/_observability.py
+++ b/src/charmed_kubeflow_chisme/testing/_observability.py
@@ -1,10 +1,10 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import logging
 import json
-import requests
+import logging
 
+import requests
 
 log = logging.getLogger(__name__)
 
@@ -24,10 +24,7 @@ async def prometheus_grafana_integration_test(application_name: str, ops_test):
     # Deploy and relate prometheus
     await ops_test.model.deploy(prometheus, channel="latest/edge", trust=True)
     await ops_test.model.deploy(grafana, channel="latest/edge", trust=True)
-    await ops_test.model.deploy(
-        prometheus_scrape,
-        channel="latest/beta",
-        config=scrape_config)
+    await ops_test.model.deploy(prometheus_scrape, channel="latest/beta", config=scrape_config)
 
     await ops_test.model.add_relation(application_name, prometheus_scrape)
     await ops_test.model.add_relation(
@@ -43,13 +40,11 @@ async def prometheus_grafana_integration_test(application_name: str, ops_test):
     await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
 
     status = await ops_test.model.get_status()
-    prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"][
-        "address"
-    ]
+    prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"]["address"]
     log.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
 
     r = requests.get(
-        f'http://{prometheus_unit_ip}:9090/api/v1/query?query='
+        f"http://{prometheus_unit_ip}:9090/api/v1/query?query="
         f'up{{juju_application="{application_name}"}}'
     )
     response = json.loads(r.content.decode("utf-8"))

--- a/src/charmed_kubeflow_chisme/testing/_observability.py
+++ b/src/charmed_kubeflow_chisme/testing/_observability.py
@@ -1,0 +1,58 @@
+import logging
+import json
+import requests
+
+
+log = logging.getLogger(__name__)
+
+
+async def test_prometheus_grafana_integration(application_name: str, ops_test):
+    """Deploy prometheus, grafana and required relations, then test the metrics.
+
+    TODO: Should grafana and prometheus be fixtures here, so they don't stay around?  Or should
+          we just treat them as part of the model, and if they'll break other tests then they
+          should be in a separate test file?
+    """
+    prometheus = "prometheus-k8s"
+    grafana = "grafana-k8s"
+    prometheus_scrape = "prometheus-scrape-config-k8s"
+    scrape_config = {"scrape_interval": "30s"}
+
+    # Deploy and relate prometheus
+    await ops_test.model.deploy(prometheus, channel="latest/edge", trust=True)
+    await ops_test.model.deploy(grafana, channel="latest/edge", trust=True)
+    await ops_test.model.deploy(
+        prometheus_scrape,
+        channel="latest/beta",
+        config=scrape_config)
+
+    await ops_test.model.add_relation(application_name, prometheus_scrape)
+    await ops_test.model.add_relation(
+        f"{prometheus}:grafana-dashboard", f"{grafana}:grafana-dashboard"
+    )
+    await ops_test.model.add_relation(
+        f"{application_name}:grafana-dashboard", f"{grafana}:grafana-dashboard"
+    )
+    await ops_test.model.add_relation(
+        f"{prometheus}:metrics-endpoint", f"{prometheus_scrape}:metrics-endpoint"
+    )
+
+    await ops_test.model.wait_for_idle(status="active", timeout=60 * 10)
+
+    status = await ops_test.model.get_status()
+    prometheus_unit_ip = status["applications"][prometheus]["units"][f"{prometheus}/0"][
+        "address"
+    ]
+    log.info(f"Prometheus available at http://{prometheus_unit_ip}:9090")
+
+    r = requests.get(
+        f'http://{prometheus_unit_ip}:9090/api/v1/query?query=up{{juju_application="{application_name}"}}'
+    )
+    response = json.loads(r.content.decode("utf-8"))
+    response_status = response["status"]
+    log.info(f"Response status is {response_status}")
+    assert response_status == "success"
+
+    response_metric = response["data"]["result"][0]["metric"]
+    assert response_metric["juju_application"] == application_name
+    assert response_metric["juju_model"] == ops_test.model_name


### PR DESCRIPTION
This adds a reusable observability charm test code so we can share it across multiple charms.  See canonical/metacontroller-operator#19 for an example usage

Todo:
* [ ] Add a retry mechanic to the `requests.get()` like [here](https://github.com/canonical/kfp-operators/blob/6d5d98462dd60d012246b0031a3d924a9822661a/charms/kfp-api/tests/integration/test_charm.py#L86) to make this less flaky
* [ ] Check with Observability - is this a suitable test?  Do they have suggestions?
* [ ] Add configuration for the channels of the observability charms
