### PR TITLE
feat: add tools for interacting with bundles and juju CLI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,11 @@ package_dir =
 packages = find:
 python_requires = >=3.6
 install_requires =
+    deepdiff
     jinja2
     lightkube > 0.10.0
     ops > 1.2.0
+    ruamel.yaml
 
 [options.extras_require]
 test =

--- a/src/charmed_kubeflow_chisme/bundle/__init__.py
+++ b/src/charmed_kubeflow_chisme/bundle/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helpers for interacting with Charm Bundles."""
+
+from ._bundle import Bundle
+
+__all__ = [Bundle]

--- a/src/charmed_kubeflow_chisme/bundle/_bundle.py
+++ b/src/charmed_kubeflow_chisme/bundle/_bundle.py
@@ -25,8 +25,10 @@ class Bundle:
     def __init__(self, filename: Optional[str] = None):
         self._filename = filename
         self._data = None
+
+        # Auto-load the bundle if a filename is provided
         if self._filename:
-            self.load_bundle()
+            self._load_bundle()
 
     def deepcopy(self) -> Bundle:
         """Returns a new deep copy of this Bundle."""
@@ -67,7 +69,14 @@ class Bundle:
         return newbundle
 
     def load_bundle(self):
-        """Loads a YAML file as a bundle."""
+        """Loads a YAML file as a bundle.
+
+        This is triggered by default on __init__ if a filename is provided to the bundle, but can
+        be used by a user to re-load the bundle from disk or to load a bundle if filename was not
+        originally provided.
+
+        This method will raise errors from pathlib.Path if the file does not exist.
+        """
         yaml = YAML(typ="rt")
         self._data = yaml.load(Path(self._filename).read_text())
 

--- a/src/charmed_kubeflow_chisme/bundle/_bundle.py
+++ b/src/charmed_kubeflow_chisme/bundle/_bundle.py
@@ -1,0 +1,91 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Helper to work with Juju bundles, preserving comments in the YAML"""
+
+import copy
+from pathlib import Path
+from typing import Optional
+
+from deepdiff import DeepDiff
+from ruamel.yaml import YAML
+
+from ..juju import Juju
+
+
+class Bundle:
+    """Juju bundle loader/dumper.
+
+    This class uses ruamel.yaml instead of the typical pyyaml in order to preserve all comments,
+    the order of the yaml, etc.  This way we can load/dump a yaml with comments without losing them
+    or reordering the items.
+    """
+
+    def __init__(self, filename: Optional[str] = None):
+        self._filename = filename
+        self._data = None
+        if self._filename:
+            self.load_bundle()
+
+    def deepcopy(self):
+        """Returns a new deep copy of this Bundle"""
+        newbundle = copy.deepcopy(self)
+        return newbundle
+
+    def diff(self, other):
+        """Returns a diff between this and another object, in DeepDiff format"""
+        return DeepDiff(self._data, other._data, ignore_order=True)
+
+    def dump(self, filename: str):
+        """Dumps as yaml to a file"""
+        with open(filename, "w") as fout:
+            yaml = YAML(typ="rt")
+            yaml.dump(self.to_dict(), fout)
+
+    def get_latest_revisions(self):
+        """Return a new Bundle that has the latest revisions of all charms in this bundle"""
+        newbundle = self.deepcopy()
+
+        applications = newbundle.applications
+
+        for name, application in applications.items():
+            # Skip charms we're not "tracking" a channel for
+            if "_tracked_channel" not in application:
+                continue
+
+            charm_name = application["charm"]
+            channel = application["_tracked_channel"]
+            revision = application.get("revision", None)
+
+            newest_revision = get_newest_charm_revision(charm_name, channel)
+
+            if revision != newest_revision:
+                # If revision is not up to date - update in situ from tracked channel
+                application["revision"] = newest_revision
+
+        return newbundle
+
+    def load_bundle(self):
+        """Loads a YAML file as a bundle"""
+        yaml = YAML(typ="rt")
+        self._data = yaml.load(Path(self._filename).read_text())
+
+    def to_dict(self):
+        return self._data
+
+    def __eq__(self, other):
+        return self._filename == other._filename and self.diff(other) == {}
+
+    @property
+    def applications(self):
+        return self._data["applications"]
+
+
+def get_newest_charm_revision(charm: str, channel: str):
+    """Returns the newest revision of a charm in a channel"""
+    charm_info = Juju.info(charm)
+    channel_map = charm_info["channel-map"]
+    try:
+        tracked_channel_release = channel_map[channel]
+    except KeyError:
+        raise ValueError(f"No channel {channel} in `juju info {charm} --format yaml`")
+    return tracked_channel_release["revision"]

--- a/src/charmed_kubeflow_chisme/bundle/_bundle.py
+++ b/src/charmed_kubeflow_chisme/bundle/_bundle.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 """Helper to work with Juju bundles, preserving comments in the YAML"""
 
+from __future__ import annotations
 import copy
 from pathlib import Path
 from typing import Optional
@@ -26,12 +27,12 @@ class Bundle:
         if self._filename:
             self.load_bundle()
 
-    def deepcopy(self):
+    def deepcopy(self) -> Bundle:
         """Returns a new deep copy of this Bundle"""
         newbundle = copy.deepcopy(self)
         return newbundle
 
-    def diff(self, other):
+    def diff(self, other: Bundle) -> DeepDiff:
         """Returns a diff between this and another object, in DeepDiff format"""
         return DeepDiff(self._data, other._data, ignore_order=True)
 
@@ -41,7 +42,7 @@ class Bundle:
             yaml = YAML(typ="rt")
             yaml.dump(self.to_dict(), fout)
 
-    def get_latest_revisions(self):
+    def get_latest_revisions(self) -> Bundle:
         """Return a new Bundle that has the latest revisions of all charms in this bundle"""
         newbundle = self.deepcopy()
 
@@ -69,18 +70,18 @@ class Bundle:
         yaml = YAML(typ="rt")
         self._data = yaml.load(Path(self._filename).read_text())
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         return self._data
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         return self._filename == other._filename and self.diff(other) == {}
 
     @property
-    def applications(self):
+    def applications(self) -> dict:
         return self._data["applications"]
 
 
-def get_newest_charm_revision(charm: str, channel: str):
+def get_newest_charm_revision(charm: str, channel: str) -> str:
     """Returns the newest revision of a charm in a channel"""
     charm_info = Juju.info(charm)
     channel_map = charm_info["channel-map"]

--- a/src/charmed_kubeflow_chisme/bundle/_bundle.py
+++ b/src/charmed_kubeflow_chisme/bundle/_bundle.py
@@ -68,7 +68,7 @@ class Bundle:
 
         return newbundle
 
-    def load_bundle(self):
+    def _load_bundle(self):
         """Loads a YAML file as a bundle.
 
         This is triggered by default on __init__ if a filename is provided to the bundle, but can

--- a/src/charmed_kubeflow_chisme/bundle/_bundle.py
+++ b/src/charmed_kubeflow_chisme/bundle/_bundle.py
@@ -1,8 +1,9 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-"""Helper to work with Juju bundles, preserving comments in the YAML"""
+"""Helper to work with Juju bundles, preserving comments in the YAML."""
 
 from __future__ import annotations
+
 import copy
 from pathlib import Path
 from typing import Optional
@@ -28,22 +29,22 @@ class Bundle:
             self.load_bundle()
 
     def deepcopy(self) -> Bundle:
-        """Returns a new deep copy of this Bundle"""
+        """Returns a new deep copy of this Bundle."""
         newbundle = copy.deepcopy(self)
         return newbundle
 
     def diff(self, other: Bundle) -> DeepDiff:
-        """Returns a diff between this and another object, in DeepDiff format"""
+        """Returns a diff between this and another object, in DeepDiff format."""
         return DeepDiff(self._data, other._data, ignore_order=True)
 
     def dump(self, filename: str):
-        """Dumps as yaml to a file"""
+        """Dumps as yaml to a file."""
         with open(filename, "w") as fout:
             yaml = YAML(typ="rt")
             yaml.dump(self.to_dict(), fout)
 
     def get_latest_revisions(self) -> Bundle:
-        """Return a new Bundle that has the latest revisions of all charms in this bundle"""
+        """Return a new Bundle that has the latest revisions of all charms in this bundle."""
         newbundle = self.deepcopy()
 
         applications = newbundle.applications
@@ -66,23 +67,26 @@ class Bundle:
         return newbundle
 
     def load_bundle(self):
-        """Loads a YAML file as a bundle"""
+        """Loads a YAML file as a bundle."""
         yaml = YAML(typ="rt")
         self._data = yaml.load(Path(self._filename).read_text())
 
     def to_dict(self) -> dict:
+        """Returns this bundle as a dict."""
         return self._data
 
     def __eq__(self, other) -> bool:
+        """Returns True if this bundle is equal to another bundle."""
         return self._filename == other._filename and self.diff(other) == {}
 
     @property
     def applications(self) -> dict:
+        """Returns the bundle's applications dict."""
         return self._data["applications"]
 
 
 def get_newest_charm_revision(charm: str, channel: str) -> str:
-    """Returns the newest revision of a charm in a channel"""
+    """Returns the newest revision of a charm in a channel."""
     charm_info = Juju.info(charm)
     channel_map = charm_info["channel-map"]
     try:

--- a/src/charmed_kubeflow_chisme/juju/__init__.py
+++ b/src/charmed_kubeflow_chisme/juju/__init__.py
@@ -3,6 +3,6 @@
 
 """Helpers for interacting with Charm Bundles."""
 
-from ._juju import Juju
+from ._juju import juju, info, JujuFailedError
 
-__all__ = [Juju]
+__all__ = [juju, info, JujuFailedError]

--- a/src/charmed_kubeflow_chisme/juju/__init__.py
+++ b/src/charmed_kubeflow_chisme/juju/__init__.py
@@ -3,6 +3,6 @@
 
 """Helpers for interacting with Charm Bundles."""
 
-from ._juju import juju, info, JujuFailedError
+from ._juju import JujuFailedError, info, juju
 
-__all__ = [juju, info, JujuFailedError]
+__all__ = [JujuFailedError, info, juju]

--- a/src/charmed_kubeflow_chisme/juju/__init__.py
+++ b/src/charmed_kubeflow_chisme/juju/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helpers for interacting with Charm Bundles."""
+
+from ._juju import Juju
+
+__all__ = [Juju]

--- a/src/charmed_kubeflow_chisme/juju/_juju.py
+++ b/src/charmed_kubeflow_chisme/juju/_juju.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Helper for shelling out to the Juju CLI"""
+
+from subprocess import Popen, PIPE
+from ruamel.yaml import YAML
+
+
+class Juju:
+    @staticmethod
+    def juju(*args, raise_on_stderr: bool=False):
+        cmd = ["juju"] + list(args)
+        proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
+        stdout = proc.stdout.read().decode('utf-8')
+        stderr = proc.stderr.read().decode('utf-8')
+        if raise_on_stderr and stderr:
+            raise ValueError(f"failed to run juju command successfully.  Got this from stderr: {stderr}")
+        return stdout, stderr
+
+    @classmethod
+    def info(cls, charm_name: str):
+        stdout, stderr = cls.juju("info", charm_name, "--format", "yaml", raise_on_stderr=False)
+        failure_message = f"Failed to load valid yaml from `juju info`"
+        try:
+            yaml = YAML(typ='rt')
+            data_dict = yaml.load(stdout)
+        except Exception:  # TODO: This should be more specific
+            raise JujuFailedError(failure_message, stderr=stderr, stdout=stdout)
+
+        if not data_dict:
+            raise JujuFailedError(failure_message, stderr=stderr, stdout=stdout)
+
+        return data_dict
+
+
+class JujuFailedError(Exception):
+    """Error raised when calls to the Juju CLI fail.  Includes stderr and stdout of the call."""
+    def __init__(self, msg: str, stderr: str, stdout: str):
+        super().__init__(str(msg))
+        self.stderr = stderr
+        self.stdout = stdout

--- a/src/charmed_kubeflow_chisme/juju/_juju.py
+++ b/src/charmed_kubeflow_chisme/juju/_juju.py
@@ -1,30 +1,35 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-"""Helper for shelling out to the Juju CLI"""
+"""Helper for shelling out to the Juju CLI."""
 
-from subprocess import Popen, PIPE
+from subprocess import PIPE, Popen
+
 from ruamel.yaml import YAML
 
 
 class Juju:
+    """Helper for shelling out to the Juju CLI."""
+
     @staticmethod
     def juju(*args, raise_on_stderr: bool = False) -> tuple[str, str]:
-        """Run a Juju CLI command and return the output, optionally raising on error"""
+        """Run a Juju CLI command and return the output, optionally raising on error."""
         cmd = ["juju"] + list(args)
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
-        stdout = proc.stdout.read().decode('utf-8')
-        stderr = proc.stderr.read().decode('utf-8')
+        stdout = proc.stdout.read().decode("utf-8")
+        stderr = proc.stderr.read().decode("utf-8")
         if raise_on_stderr and stderr:
-            raise ValueError(f"failed to run juju command successfully.  Got this from stderr: {stderr}")
+            raise ValueError(
+                f"failed to run juju command successfully.  Got this from stderr: {stderr}"
+            )
         return stdout, stderr
 
     @classmethod
     def info(cls, charm_name: str) -> dict:
-        """Convenience method to call `juju info` and return the parsed output"""
+        """Convenience method to call `juju info` and return the parsed output."""
         stdout, stderr = cls.juju("info", charm_name, "--format", "yaml", raise_on_stderr=False)
-        failure_message = f"Failed to load valid yaml from `juju info`"
+        failure_message = "Failed to load valid yaml from `juju info`"
         try:
-            yaml = YAML(typ='rt')
+            yaml = YAML(typ="rt")
             data_dict = yaml.load(stdout)
         except Exception:  # TODO: This should be more specific
             raise JujuFailedError(failure_message, stderr=stderr, stdout=stdout)
@@ -37,6 +42,7 @@ class Juju:
 
 class JujuFailedError(Exception):
     """Error raised when calls to the Juju CLI fail.  Includes stderr and stdout of the call."""
+
     def __init__(self, msg: str, stderr: str, stdout: str):
         super().__init__(str(msg))
         self.stderr = stderr

--- a/src/charmed_kubeflow_chisme/juju/_juju.py
+++ b/src/charmed_kubeflow_chisme/juju/_juju.py
@@ -8,7 +8,8 @@ from ruamel.yaml import YAML
 
 class Juju:
     @staticmethod
-    def juju(*args, raise_on_stderr: bool=False):
+    def juju(*args, raise_on_stderr: bool = False) -> tuple[str, str]:
+        """Run a Juju CLI command and return the output, optionally raising on error"""
         cmd = ["juju"] + list(args)
         proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
         stdout = proc.stdout.read().decode('utf-8')
@@ -18,7 +19,8 @@ class Juju:
         return stdout, stderr
 
     @classmethod
-    def info(cls, charm_name: str):
+    def info(cls, charm_name: str) -> dict:
+        """Convenience method to call `juju info` and return the parsed output"""
         stdout, stderr = cls.juju("info", charm_name, "--format", "yaml", raise_on_stderr=False)
         failure_message = f"Failed to load valid yaml from `juju info`"
         try:


### PR DESCRIPTION
This PR adds tools to make it easier to interact with charm bundles and the Juju CLI.  

Bundle class adds things like loading bundles from yaml, comparing bundles, diffing bundles.  Also included is the get_newest_charm_revision() helper, which retrieves from `juju info` cli command what the newest charm revision is for a charm in a particular channel.

Juju class and helpers add some convenience functions and structure around calling the juju cli