### PR TITLE
feat: enable auto-generation of generic resources

### DIFF
--- a/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
+++ b/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
@@ -140,10 +140,12 @@ class KubernetesResourceHandler:
                             used `self.context = context; self.render_manifests()` more convenient.
             force_recompute (bool): If true, will always recompute manifests even if cached
                                     manifests are available
-            create_resources_for_crds (bool): If True, a generic resource will be created for every version of every
-                                              CRD found that does not already have a generic resource.  There will be no
-                                              side effect for any CRD that already has a generic resource.  Else if
-                                              False, no generic resources.  Default is True
+            create_resources_for_crds (bool): If True, a generic resource will be created for
+                                              every version of every CRD found that does not
+                                              already have a generic resource.  There will be no
+                                              side effect for any CRD that already has a generic
+                                              resource.  Else if False, no generic resources.
+                                              Default is True
         """
         self.log.info("Rendering manifests")
 

--- a/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
+++ b/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
@@ -122,6 +122,7 @@ class KubernetesResourceHandler:
         template_files: Optional[Iterable[str]] = None,
         context: Optional[dict] = None,
         force_recompute: bool = False,
+        create_resources_for_crds: bool = True,
     ) -> LightkubeResourcesList:
         """Renders this charm's manifests, returning them as a list of Lightkube Resources.
 
@@ -139,6 +140,10 @@ class KubernetesResourceHandler:
                             used `self.context = context; self.render_manifests()` more convenient.
             force_recompute (bool): If true, will always recompute manifests even if cached
                                     manifests are available
+            create_resources_for_crds (bool): If True, a generic resource will be created for every version of every
+                                              CRD found that does not already have a generic resource.  There will be no
+                                              side effect for any CRD that already has a generic resource.  Else if
+                                              False, no generic resources.  Default is True
         """
         self.log.info("Rendering manifests")
 
@@ -163,7 +168,9 @@ class KubernetesResourceHandler:
         manifest_parts = self._render_manifest_parts()
 
         # Cache for later use
-        self._manifests = codecs.load_all_yaml("\n---\n".join(manifest_parts))
+        self._manifests = codecs.load_all_yaml(
+            "\n---\n".join(manifest_parts), create_resources_for_crds=create_resources_for_crds
+        )
         return self._manifests
 
     def _render_manifest_parts(self):

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8==4.0.1
+    flake8
     flake8-docstrings
     flake8-copyright
     flake8-builtins
@@ -41,10 +41,11 @@ deps =
     isort
     codespell
 commands =
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-    --skip {toxinidir}/venv --skip {toxinidir}/.mypy_cache \
-    --skip {toxinidir}/icon.svg
-# pflake8 wrapper supports config from pyproject.toml
+    codespell {toxinidir}/. --skip {toxinidir}/./.git --skip {toxinidir}/./.tox \
+      --skip {toxinidir}/./venv \
+      --skip {toxinidir}/./.mypy_cache \
+      --skip {toxinidir}/./icon.svg --skip *.json.tmpl
+    # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]all_path}
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}


### PR DESCRIPTION
Exposes `lightkube.load_all_yaml()`'s `create_resources_for_crds` argument as `KubernetesResourceHandler.render_manifests(create_resources_for_crds=True)`.  This lets users of the KubernetesResourceHandler automatically generate generic resources as they load new CRDs.