### PR TITLE
fix: pin deepdiff==6.2.1 to avoid build time error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ package_dir =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    deepdiff
+    deepdiff==6.2.1
     jinja2
     lightkube > 0.10.0
     ops > 1.2.0


### PR DESCRIPTION
There is a dependency in deepdiff (orjson) which requires rust to be present in the charm when installing pip packages, causing an error if it's not. To avoid the error, we can pin deepdiff to version 6.2.1 which has a dependency tree that does not require rust.

Fixes #42