### PR TITLE
fix: loosen pinning of `deepdiff`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ package_dir =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    deepdiff==6.2.1
+    deepdiff<=6.2.1
     jinja2
     lightkube > 0.10.0
     ops > 1.2.0


### PR DESCRIPTION
Previously we pinned to exactly `deepdiff==6.2.1` to avoid compile issues, but really we can accept an older version as well.  Our only constraint is nothing newer than 6.2.1