### PR TITLE
remove tox publish

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -73,17 +73,3 @@ commands =
     coverage run --source={[vars]src_path} \
     -m pytest {[vars]tst_path}/integration -v --tb native -s {posargs}
     coverage report
-
-[testenv:publish]
-; to test, use `tox -e publish -- --repository testpypi` to upload to test.pypi.org
-description = Publish to PyPI
-allowlist_externals =
-    rm
-deps =
-    build
-    twine
-commands=
-    rm -rf build/ *-egg-info/ dist
-    python -m build
-    twine check {toxinidir}/dist/*
-    twine upload {posargs} {toxinidir}/dist/*


### PR DESCRIPTION
publish should be done via instruction in [README](https://github.com/canonical/charmed-kubeflow-chisme#publishing-to-pypi)