### PR TITLE
feat: Extend GenericCharmRuntimeError with args

### DIFF
--- a/src/charmed_kubeflow_chisme/exceptions/_generic_charm_runtime_error.py
+++ b/src/charmed_kubeflow_chisme/exceptions/_generic_charm_runtime_error.py
@@ -21,6 +21,6 @@ class GenericCharmRuntimeError(Exception):
 
     __module__ = None
 
-    def __init__(self, msg: str):
-        super().__init__(str(msg))
+    def __init__(self, msg: str, *args):
+        super().__init__(str(msg), *args)
         self.msg = str(msg)


### PR DESCRIPTION
Extend `GenericCharmRuntimeError` to receive a list of `args` and propagate these to the `BaseException` initialisation.