### PR TITLE
feat: Add error handling for deleting resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = charmed-kubeflow-chisme
-version = 0.0.11
+version = 0.1.0
 author = Charmed Kubeflow
 description = A collection of helpers for Charms maintained by the Charmed Kubeflow team
 long_description = file: README.md

--- a/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
+++ b/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
@@ -152,7 +152,7 @@ class KubernetesResourceHandler:
         _validate_labels_and_resource_types(self.labels, self.resource_types, caller_name="delete")
 
         resources_to_delete = self.get_deployed_resources()
-        delete_many(self.lightkube_client, resources_to_delete, ignore_missing)
+        delete_many(self.lightkube_client, resources_to_delete, ignore_missing, self.log)
 
     def get_deployed_resources(self) -> LightkubeResourcesList:
         """Returns a list of all resources deployed by this KubernetesResourceHandler.
@@ -207,7 +207,7 @@ class KubernetesResourceHandler:
         resources_to_delete = _in_left_not_right(
             existing_resources, desired_resources, hasher=_hash_lightkube_resource
         )
-        delete_many(self._lightkube_client, resources_to_delete, ignore_missing)
+        delete_many(self._lightkube_client, resources_to_delete, ignore_missing, self.log)
 
         # Update remaining resources and create any new ones
         self.apply(force=force)
@@ -333,7 +333,7 @@ class KubernetesResourceHandler:
                 ) from e
 
         try:
-            apply_many(client=self.lightkube_client, objs=resources, force=force)
+            apply_many(client=self.lightkube_client, objs=resources, force=force, logger=self.log)
         except ApiError as e:
             if e.status.code == 403:
                 # Handle forbidden error as this likely means we do not have --trust

--- a/src/charmed_kubeflow_chisme/lightkube/batch/_many.py
+++ b/src/charmed_kubeflow_chisme/lightkube/batch/_many.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 from typing import Iterable, TypeVar, Union
 
 import lightkube
@@ -10,6 +11,8 @@ from lightkube.core.resource import GlobalResource, NamespacedResource
 
 # Replace with lightkube.sort_objects once gtsystem/lightkube#33 is merged
 from ._sort_objects import _sort_objects as sort_objects
+
+LOGGER = logging.getLogger(__name__)
 
 GlobalResourceTypeVar = TypeVar("GlobalResource", bound=resource.GlobalResource)
 GlobalSubResourceTypeVar = TypeVar("GlobalSubResource", bound=resource.GlobalSubResource)
@@ -21,6 +24,7 @@ def apply_many(
     objs: Iterable[Union[GlobalResourceTypeVar, NamespacedResourceTypeVar]],
     field_manager: str = None,
     force: bool = False,
+    logger: logging.Logger = None,
 ) -> Iterable[Union[GlobalResourceTypeVar, NamespacedResourceTypeVar]]:
     """Create or configure an iterable of Lightkube objects using client.apply().
 
@@ -38,17 +42,19 @@ def apply_many(
 
     Args:
         client: Lightkube client to use for applying resources
-        objs:  iterable of objects to create. This need to be instances of a resource kind and have
-               resource.metadata.namespaced defined if they are namespaced resources
+        objs: Iterable of objects to create. This need to be instances of a resource kind and have
+              resource.metadata.namespaced defined if they are namespaced resources
         field_manager: Name associated with the actor or entity that is making these changes.
         force: *(optional)* Force is going to "force" Apply requests. It means user will
                re-acquire conflicting fields owned by other people.
+        logger: *(optional)* Logger to use for applying resources
 
     Returns:
         A list of Resource objects returned from client.apply().  This list is returned in the
         order the resources were actually applied, not the order in which they're passed as inputs
         in `objs`.
     """
+    logger = logger or LOGGER
     objs = sort_objects(objs)
     returns = [None] * len(objs)
 
@@ -62,6 +68,7 @@ def apply_many(
                 f"apply_many only supports objects of types NamespacedResource or GlobalResource,"
                 f" got {type(obj)}"
             )
+        logger.debug(f"Creating {obj.__class__} {obj.metadata.name}...")
         returns[i] = client.apply(
             obj=obj, namespace=namespace, field_manager=field_manager, force=force
         )
@@ -72,6 +79,7 @@ def delete_many(
     client: lightkube.Client,
     objs: Iterable[Union[GlobalResourceTypeVar, NamespacedResourceTypeVar]],
     ignore_missing: bool = True,
+    logger: logging.Logger = None,
 ) -> None:
     """Delete an iterable of objects using client.delete().
 
@@ -83,7 +91,9 @@ def delete_many(
         objs: Iterable of objects to delete. This need to be instances of a resource kind and have
               resource.metadata.namespaced defined if they are namespaced resources
         ignore_missing: *(optional)* Avoid raising 404 errors on deletion (defaults to True)
+        logger: *(optional)* Logger to use for deleting resources
     """
+    logger = logger or LOGGER
     objs = sort_objects(objs, reverse=True)
     exceptions = []
 
@@ -98,11 +108,16 @@ def delete_many(
                 f" got {type(obj)}"
             )
         try:
+            logger.debug(f"Deleting {obj.__class__} {obj.metadata.name}...")
             client.delete(res=obj.__class__, name=obj.metadata.name, namespace=namespace)
         except ApiError as error:
             if error.status.code == 404 and ignore_missing:
-                continue
+                logger.debug(
+                    f"{obj.__class__} {obj.metadata.name} not found! Ignoring because"
+                    f" ignore_missing={ignore_missing}."
+                )
             else:
+                logger.debug(f"Failed to delete {obj.__class__} {obj.metadata.name}: {error}")
                 exceptions.append(error)
 
     if exceptions:


### PR DESCRIPTION
Capture `ApiErrors` when attempting to delete K8s resources and provide an option to ignore 404 errors, since they don't affect the deletion. Catch everything else and raise it at the end, after deletion is attempted for all detected resources. 

Add logging to the `apply_many` and `delete_many` helpers.