### PR TITLE
feat: Store managed K8s resource types in a set

### DIFF
--- a/src/charmed_kubeflow_chisme/kubernetes/README.md
+++ b/src/charmed_kubeflow_chisme/kubernetes/README.md
@@ -61,11 +61,11 @@ krh.compute_unit_status()
 
 These helpers encapsulate the logic around looping through each template, rendering them with the context to get `Lightkube.Resource` objects, `apply`ing them to the Kubernetes Cluster in a safe order, etc.  
 
-If we plan on managing these resources over time, we can provide the optional `labels` and `child_resource_types` arguments:
+If we plan on managing these resources over time, we can provide the optional `labels` and `resource_types` arguments:
 * `labels`: a set of labels used to identify the resources deployed by this resource handler, even during separate charm executions.  Use the included `create_charm_default_labels` for a standard set of labels.
-* `child_resource_types`: a list of `Lightkube.Resource` types that are expected to be deployed by this resource handler.
+* `resource_types`: a set of `Lightkube.Resource` types that are expected to be deployed by this resource handler.
 
-By adding `labels` and `child_resource_types`, we can manage deployed resources including through reconciliation and deletion.  For example, if we have a `Deployment` and a `Service` that are both deployed by this resource handler, we can provide `child_resource_types=[Deployment, Service]` to the constructor.  This will allow us to later get all resources deployed by this resource handler by querying the cluster for all resources with the labels defined in `labels` and of type `Deployment` or `Service`.  
+By adding `labels` and `resource_types`, we can manage deployed resources including through reconciliation and deletion.  For example, if we have a `Deployment` and a `Service` that are both deployed by this resource handler, we can provide `resource_types={Deployment, Service}` to the constructor.  This will allow us to later get all resources deployed by this resource handler by querying the cluster for all resources with the labels defined in `labels` and of type `Deployment` or `Service`.
 
 For example:
 
@@ -77,11 +77,11 @@ krh = KubernetesResourceHandler(
     labels=create_charm_default_labels(
         application_name="my-application", model_name="my-model", scope="my-scope"
     ),
-    child_resource_types=[Service]
+    resource_types={Service},
 )
 
 # Get the resources we currently have deployed
-# (this uses the labels and child_resource_types defined in the constructor.  See the docstring for more details)
+# (this uses the labels and resource_types defined in the constructor.  See the docstring for more details)
 current_resources = krh.get_deployed_resources()
 # Returns []
 

--- a/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
+++ b/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
@@ -23,7 +23,7 @@ from ..types._charm_status import AnyCharmStatus
 from ._check_resources import check_resources
 
 ERROR_MESSAGE_NO_LABELS = "{caller} requires labels to be set"
-ERROR_MESSAGE_NO_RESOURCE_TYPES = "{caller} requires labels to be set"
+ERROR_MESSAGE_NO_RESOURCE_TYPES = "{caller} requires labels to be defined"
 
 
 def auto_clear_manifests_cache(func):

--- a/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
+++ b/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import functools
 import logging
@@ -23,7 +23,7 @@ from ..types._charm_status import AnyCharmStatus
 from ._check_resources import check_resources
 
 ERROR_MESSAGE_NO_LABELS = "{caller} requires labels to be set"
-ERROR_MESSAGE_NO_CHILD_RESOURCE_TYPES = "{caller} requires labels to be set"
+ERROR_MESSAGE_NO_RESOURCE_TYPES = "{caller} requires labels to be set"
 
 
 def auto_clear_manifests_cache(func):
@@ -52,7 +52,7 @@ class KubernetesResourceHandler:
         context: Optional[dict] = None,
         logger: Optional[logging.Logger] = None,
         labels: Optional[dict] = None,
-        child_resource_types: LightkubeResourceTypesSet = None,
+        resource_types: LightkubeResourceTypesSet = None,
     ):
         """Returns a KubernetesResourceHandler instance.
 
@@ -81,17 +81,16 @@ class KubernetesResourceHandler:
                               'kubernetes-resource-handler-scope': 'some-user-chosen-scope'
                              }
                            See `get_default_labels` for a helper to generate this label dict.
-            child_resource_types (set): (Optional) Set of Lightkube Resource objects that define
-                                         the types of child resources managed by this KRH.
-                                         Must be set to use .delete(), .reconcile(), or
-                                         .get_deployed_resources().
+            resource_types (set): (Optional) Set of Lightkube Resource objects that define the
+                                   types of child resources managed by this KRH. Must be set to use
+                                   .delete(), .reconcile(), or .get_deployed_resources().
         """
         self._template_files = None
         self.template_files = template_files
         self._context = None
         self.context = context
         self._field_manager = field_manager
-        self.child_resource_types = child_resource_types or set()
+        self.resource_types = resource_types or set()
         self._labels = None
         self.labels = labels
 
@@ -145,11 +144,9 @@ class KubernetesResourceHandler:
     def delete(self):
         """Deletes all resources managed by this KubernetesResourceHandler.
 
-        Requires that self.labels and self.child_resource_types be set.
+        Requires that self.labels and self.resource_types be set.
         """
-        _validate_labels_and_child_resource_types(
-            self.labels, self.child_resource_types, caller_name="delete"
-        )
+        _validate_labels_and_resource_types(self.labels, self.resource_types, caller_name="delete")
 
         resources_to_delete = self.get_deployed_resources()
         delete_many(self.lightkube_client, resources_to_delete)
@@ -157,20 +154,20 @@ class KubernetesResourceHandler:
     def get_deployed_resources(self) -> LightkubeResourcesList:
         """Returns a list of all resources deployed by this KubernetesResourceHandler.
 
-        Requires that self.labels and self.child_resource_types be set.
+        Requires that self.labels and self.resource_types be set.
 
         This method will:
-        * for each resource type included in self.child_resource_types
+        * for each resource type included in self.resource_types
           * get all resources of that type in the Kubernetes cluster that match the label selector
             defined in self.labels
 
         Returns: A list of Lightkube Resource objects
         """
-        _validate_labels_and_child_resource_types(
-            self.labels, self.child_resource_types, caller_name="get_deployed_resources"
+        _validate_labels_and_resource_types(
+            self.labels, self.resource_types, caller_name="get_deployed_resources"
         )
         resources = []
-        for resource_type in self.child_resource_types:
+        for resource_type in self.resource_types:
             if issubclass(resource_type, NamespacedResource):
                 # Get resources from all namespaces
                 namespace = "*"
@@ -189,8 +186,8 @@ class KubernetesResourceHandler:
         This method will:
         * compute a list of Lightkube Resources that are the "desired resources" (the state we
           want, given the current context
-        * for each resource type in self.child_resource_types, get all resources currently deployed
-          that match the label selector in self.labels
+        * for each resource type in self.resource_types, get all resources currently deployed that
+          match the label selector in self.labels
         * compare the current and desired resources, deleting any resources that exist but are not
           in the desired resource list
         * .apply() to update existing objects to the desired state and create new ones
@@ -300,8 +297,8 @@ class KubernetesResourceHandler:
 
         If self.labels is set, the labels will be added to all resources before applying them.
 
-        If self.child_resource_types is set, the a ValueError will be raised if trying to create
-        a resource not in the set.
+        If self.resource_types is set, the a ValueError will be raised if trying to create a
+        resource not in the set.
 
         This function will only add or modify existing objects, it will not delete any resources.
         This includes cases where the manifests have changed over time.  For example:
@@ -322,14 +319,14 @@ class KubernetesResourceHandler:
         if self.labels is not None:
             resources = _add_labels_to_resources(resources, self.labels)
 
-        if self.child_resource_types:
+        if self.resource_types:
             try:
-                _validate_resources(resources, allowed_resource_types=self.child_resource_types)
+                _validate_resources(resources, allowed_resource_types=self.resource_types)
             except ValueError as e:
                 raise ValueError(
                     "Failed to validate resources before applying them.  This likely"
                     " means we tried to create a resource of type not listed in"
-                    " `KRH.child_resource_types`."
+                    " `KRH.resource_types`."
                 ) from e
 
         try:
@@ -498,12 +495,12 @@ def _in_left_not_right(left: list, right: list, hasher: Optional[Callable] = Non
     return items_in_left_not_right
 
 
-def _validate_labels_and_child_resource_types(labels, child_resource_types, caller_name):
-    """Validates labels and child_resource_types, raising a ValueError if either is empty."""
+def _validate_labels_and_resource_types(labels, resource_types, caller_name):
+    """Validates labels and resource_types, raising a ValueError if either is empty."""
     if not labels:
         raise ValueError(ERROR_MESSAGE_NO_LABELS.format(caller=caller_name))
-    if not child_resource_types:
-        raise ValueError(ERROR_MESSAGE_NO_CHILD_RESOURCE_TYPES.format(caller=caller_name))
+    if not resource_types:
+        raise ValueError(ERROR_MESSAGE_NO_RESOURCE_TYPES.format(caller=caller_name))
 
 
 def _validate_resources(resources, allowed_resource_types: LightkubeResourceTypesSet):

--- a/src/charmed_kubeflow_chisme/types/__init__.py
+++ b/src/charmed_kubeflow_chisme/types/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Reusable typing definitions, useful for adding type hints."""
@@ -7,12 +7,12 @@ from ._charm_status import CharmStatusType
 from ._lightkube import (
     LightkubeResourcesList,
     LightkubeResourceType,
-    LightkubeResourceTypesList,
+    LightkubeResourceTypesSet,
 )
 
 __all__ = [
     CharmStatusType,
     LightkubeResourcesList,
     LightkubeResourceType,
-    LightkubeResourceTypesList,
+    LightkubeResourceTypesSet,
 ]

--- a/src/charmed_kubeflow_chisme/types/_lightkube.py
+++ b/src/charmed_kubeflow_chisme/types/_lightkube.py
@@ -1,12 +1,12 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import List, Optional, Type, Union
+from typing import List, Optional, Set, Type, Union
 
 from lightkube.core.resource import GlobalResource, NamespacedResource
 
 LightkubeResourceType = Union[NamespacedResource, GlobalResource]
 LightkubeResourcesList = List[LightkubeResourceType]
 
-# A List of the classes of valid Lightkube Resources, not instances of those classes
-LightkubeResourceTypesList = Optional[List[Type[LightkubeResourceType]]]
+# A Set of the classes of valid Lightkube Resources, not instances of those classes
+LightkubeResourceTypesSet = Optional[Set[Type[LightkubeResourceType]]]

--- a/tests/integration/test_kubernetes.py
+++ b/tests/integration/test_kubernetes.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import logging
 import random
@@ -59,7 +59,7 @@ def test_KubernetesResourceHandler_apply(namespace):  # noqa: N802
         labels=create_charm_default_labels(
             application_name="my-application", model_name="my-model", scope="my-scope"
         ),
-        child_resource_types=[Pod, Service, Namespace],
+        child_resource_types={Pod, Service, Namespace},
     )
 
     # Name of the additional namespace we create during test

--- a/tests/integration/test_kubernetes.py
+++ b/tests/integration/test_kubernetes.py
@@ -59,7 +59,7 @@ def test_KubernetesResourceHandler_apply(namespace):  # noqa: N802
         labels=create_charm_default_labels(
             application_name="my-application", model_name="my-model", scope="my-scope"
         ),
-        child_resource_types={Pod, Service, Namespace},
+        resource_types={Pod, Service, Namespace},
     )
 
     # Name of the additional namespace we create during test

--- a/tests/unit/test_kubernetes.py
+++ b/tests/unit/test_kubernetes.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import copy
 import logging
@@ -497,8 +497,8 @@ def test_KubernetesResourceHandler_apply_with_labels(  # noqa N802
 @pytest.mark.parametrize(
     "resources, child_resource_types, expected_raised_context",
     (
-        ([statefulset_with_replicas], [Service, StatefulSet], nullcontext()),
-        ([statefulset_with_replicas], [Service], pytest.raises(ValueError)),
+        ([statefulset_with_replicas], {Service, StatefulSet}, nullcontext()),
+        ([statefulset_with_replicas], {Service}, pytest.raises(ValueError)),
     ),
 )
 def test_KubernetesResourceHandler_apply_with_child_resource_types(  # noqa N802
@@ -566,7 +566,7 @@ def test_KubernetesResourceHandler_delete():  # noqa: N802
         template_files=[],
         context={},
         labels={"some": "labels"},
-        child_resource_types=["Some", "Types"],
+        child_resource_types={"Some", "Types"},
     )
     krh._lightkube_client = mock.MagicMock()
 
@@ -586,10 +586,10 @@ def test_KubernetesResourceHandler_delete():  # noqa: N802
 @pytest.mark.parametrize(
     "labels, child_resource_types, expected_context",
     [
-        (None, ["some", "resources"], pytest.raises(ValueError)),
-        ({}, ["some", "resources"], pytest.raises(ValueError)),
+        (None, {"some", "resources"}, pytest.raises(ValueError)),
+        ({}, {"some", "resources"}, pytest.raises(ValueError)),
         ({"some": "labels"}, None, pytest.raises(ValueError)),
-        ({"some": "labels"}, [], pytest.raises(ValueError)),
+        ({"some": "labels"}, {}, pytest.raises(ValueError)),
     ],
 )
 def test_KubernetesResourceHandler_delete_missing_required_arguments(  # noqa: N802
@@ -616,7 +616,7 @@ def test_KubernetesResourceHandler_get_deployed_resources():  # noqa: N802
     """Tests that KRH.get_deployed_resources returns as expected."""
     # Arrange
     labels = {"some": "labels"}
-    child_resource_types = [Pod, Service]
+    child_resource_types = {Pod, Service}
 
     expected_resources = [
         Pod(metadata=ObjectMeta(name="pod1", namespace="namespace1")),
@@ -649,10 +649,10 @@ def test_KubernetesResourceHandler_get_deployed_resources():  # noqa: N802
 @pytest.mark.parametrize(
     "labels, child_resource_types, expected_context",
     [
-        (None, ["some", "resources"], pytest.raises(ValueError)),
-        ({}, ["some", "resources"], pytest.raises(ValueError)),
+        (None, {"some", "resources"}, pytest.raises(ValueError)),
+        ({}, {"some", "resources"}, pytest.raises(ValueError)),
         ({"some": "labels"}, None, pytest.raises(ValueError)),
-        ({"some": "labels"}, [], pytest.raises(ValueError)),
+        ({"some": "labels"}, {}, pytest.raises(ValueError)),
     ],
 )
 def test_KubernetesResourceHandler_get_deployed_resources_missing_required_arguments(  # noqa: N802
@@ -683,7 +683,7 @@ def test_KubernetesResourceHandler_reconcile():  # noqa: N802
         template_files=[],
         context={},
         labels={"name": "value", "name2": "value2"},
-        child_resource_types=[Pod, Service],
+        child_resource_types={Pod, Service},
     )
     krh._lightkube_client = mock.MagicMock()
     krh.apply = mock.MagicMock()
@@ -709,10 +709,10 @@ def test_KubernetesResourceHandler_reconcile():  # noqa: N802
 @pytest.mark.parametrize(
     "labels, child_resource_types, expected_context",
     [
-        (None, ["some", "resources"], pytest.raises(ValueError)),
-        ({}, ["some", "resources"], pytest.raises(ValueError)),
+        (None, {"some", "resources"}, pytest.raises(ValueError)),
+        ({}, {"some", "resources"}, pytest.raises(ValueError)),
         ({"some": "labels"}, None, pytest.raises(ValueError)),
-        ({"some": "labels"}, [], pytest.raises(ValueError)),
+        ({"some": "labels"}, {}, pytest.raises(ValueError)),
     ],
 )
 def test_KubernetesResourceHandler_reconcile_missing_required_arguments(  # noqa: N802
@@ -854,7 +854,7 @@ def test_add_labels_to_manifest(resources, labels, expected):
                 StatefulSet(metadata=ObjectMeta(name="name", namespace="namespace")),
                 test_global_resource(metadata=ObjectMeta(name="name")),
             ],
-            [Service, StatefulSet, test_global_resource],
+            {Service, StatefulSet, test_global_resource},
         ),
     ],
 )

--- a/tests/unit/test_kubernetes.py
+++ b/tests/unit/test_kubernetes.py
@@ -495,27 +495,27 @@ def test_KubernetesResourceHandler_apply_with_labels(  # noqa N802
 
 
 @pytest.mark.parametrize(
-    "resources, child_resource_types, expected_raised_context",
+    "resources, resource_types, expected_raised_context",
     (
         ([statefulset_with_replicas], {Service, StatefulSet}, nullcontext()),
         ([statefulset_with_replicas], {Service}, pytest.raises(ValueError)),
     ),
 )
-def test_KubernetesResourceHandler_apply_with_child_resource_types(  # noqa N802
+def test_KubernetesResourceHandler_apply_with_resource_types(  # noqa N802
     resources,
-    child_resource_types,
+    resource_types,
     expected_raised_context,
     mocker,
     simple_krh_instance,
     mocked_khr_lightkube_client_class,  # noqa F811
 ):
-    """Test KRH.apply with child_resource_types."""
+    """Test KRH.apply with resource_types."""
     # Arrange
     krh = kubernetes.KubernetesResourceHandler(
         field_manager="field-manager",
         template_files=["some-file"],
         context={"some": "context"},
-        child_resource_types=child_resource_types,
+        resource_types=resource_types,
     )
 
     mocked_render_manifests = mock.MagicMock()
@@ -566,7 +566,7 @@ def test_KubernetesResourceHandler_delete():  # noqa: N802
         template_files=[],
         context={},
         labels={"some": "labels"},
-        child_resource_types={"Some", "Types"},
+        resource_types={"Some", "Types"},
     )
     krh._lightkube_client = mock.MagicMock()
 
@@ -584,7 +584,7 @@ def test_KubernetesResourceHandler_delete():  # noqa: N802
 
 
 @pytest.mark.parametrize(
-    "labels, child_resource_types, expected_context",
+    "labels, resource_types, expected_context",
     [
         (None, {"some", "resources"}, pytest.raises(ValueError)),
         ({}, {"some", "resources"}, pytest.raises(ValueError)),
@@ -593,7 +593,7 @@ def test_KubernetesResourceHandler_delete():  # noqa: N802
     ],
 )
 def test_KubernetesResourceHandler_delete_missing_required_arguments(  # noqa: N802
-    labels, child_resource_types, expected_context
+    labels, resource_types, expected_context
 ):
     """Tests that KRH delete raises when missing required inputs."""
     # Arrange
@@ -602,7 +602,7 @@ def test_KubernetesResourceHandler_delete_missing_required_arguments(  # noqa: N
         template_files=[],
         context={},
         labels=labels,
-        child_resource_types=child_resource_types,
+        resource_types=resource_types,
     )
 
     krh._lightkube_client = mock.MagicMock()
@@ -616,7 +616,7 @@ def test_KubernetesResourceHandler_get_deployed_resources():  # noqa: N802
     """Tests that KRH.get_deployed_resources returns as expected."""
     # Arrange
     labels = {"some": "labels"}
-    child_resource_types = {Pod, Service}
+    resource_types = {Pod, Service}
 
     expected_resources = [
         Pod(metadata=ObjectMeta(name="pod1", namespace="namespace1")),
@@ -630,7 +630,7 @@ def test_KubernetesResourceHandler_get_deployed_resources():  # noqa: N802
         template_files=[],
         context={},
         labels=labels,
-        child_resource_types=child_resource_types,
+        resource_types=resource_types,
     )
 
     krh._lightkube_client = mock.MagicMock()
@@ -640,14 +640,14 @@ def test_KubernetesResourceHandler_get_deployed_resources():  # noqa: N802
     resources = krh.get_deployed_resources()
 
     # Assert list called once for each resource type
-    krh._lightkube_client.list.call_count == len(child_resource_types)
+    krh._lightkube_client.list.call_count == len(resource_types)
 
     # Assert we got the results from list
     assert resources == expected_resources
 
 
 @pytest.mark.parametrize(
-    "labels, child_resource_types, expected_context",
+    "labels, resource_types, expected_context",
     [
         (None, {"some", "resources"}, pytest.raises(ValueError)),
         ({}, {"some", "resources"}, pytest.raises(ValueError)),
@@ -656,7 +656,7 @@ def test_KubernetesResourceHandler_get_deployed_resources():  # noqa: N802
     ],
 )
 def test_KubernetesResourceHandler_get_deployed_resources_missing_required_arguments(  # noqa: N802
-    labels, child_resource_types, expected_context
+    labels, resource_types, expected_context
 ):
     """Tests that KRH.get_deployed_resources raises when missing required inputs."""
     # Arrange
@@ -665,7 +665,7 @@ def test_KubernetesResourceHandler_get_deployed_resources_missing_required_argum
         template_files=[],
         context={},
         labels=labels,
-        child_resource_types=child_resource_types,
+        resource_types=resource_types,
     )
 
     krh._lightkube_client = mock.MagicMock()
@@ -683,7 +683,7 @@ def test_KubernetesResourceHandler_reconcile():  # noqa: N802
         template_files=[],
         context={},
         labels={"name": "value", "name2": "value2"},
-        child_resource_types={Pod, Service},
+        resource_types={Pod, Service},
     )
     krh._lightkube_client = mock.MagicMock()
     krh.apply = mock.MagicMock()
@@ -707,7 +707,7 @@ def test_KubernetesResourceHandler_reconcile():  # noqa: N802
 
 
 @pytest.mark.parametrize(
-    "labels, child_resource_types, expected_context",
+    "labels, resource_types, expected_context",
     [
         (None, {"some", "resources"}, pytest.raises(ValueError)),
         ({}, {"some", "resources"}, pytest.raises(ValueError)),
@@ -716,7 +716,7 @@ def test_KubernetesResourceHandler_reconcile():  # noqa: N802
     ],
 )
 def test_KubernetesResourceHandler_reconcile_missing_required_arguments(  # noqa: N802
-    labels, child_resource_types, expected_context
+    labels, resource_types, expected_context
 ):
     """Test that KRH.reconcile raises when missing required inputs."""
     # Arrange
@@ -725,7 +725,7 @@ def test_KubernetesResourceHandler_reconcile_missing_required_arguments(  # noqa
         template_files=[],
         context={},
         labels=labels,
-        child_resource_types=child_resource_types,
+        resource_types=resource_types,
     )
     krh.apply = mock.MagicMock()
     krh._lightkube_client = mock.MagicMock()


### PR DESCRIPTION
* Rename the `child_resource_types` `KubernetesResourceHandler` field to `resource_types`
* Convert it to a set to ensure that the elements it contains are unique and allow for efficient membership checks
* Make necessary changes to tests