### PR TITLE
feat: Add set_and_log_status()

### DIFF
--- a/src/charmed_kubeflow_chisme/status_handling/__init__.py
+++ b/src/charmed_kubeflow_chisme/status_handling/__init__.py
@@ -4,7 +4,6 @@
 """Utilities for interacting with Charm Status objects."""
 
 from ._get_first_worst_error import get_first_worst_error
+from ._set_and_log_status import set_and_log_status
 
-__all__ = [
-    get_first_worst_error,
-]
+__all__ = [get_first_worst_error, set_and_log_status]

--- a/src/charmed_kubeflow_chisme/status_handling/_set_and_log_status.py
+++ b/src/charmed_kubeflow_chisme/status_handling/_set_and_log_status.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+from logging import Logger
+
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    StatusBase,
+    Unit,
+    WaitingStatus,
+)
+
+
+def set_and_log_status(unit: Unit, logger: Logger, status: StatusBase):
+    """Sets the status of the charm and logs the status message.
+
+    Args:
+        unit: The unit of which the status will be set
+        logger: The logger used for logging status' message
+        status: The status to set
+    """
+    unit.status = status
+
+    log_destination_map = {
+        ActiveStatus: logger.info,
+        BlockedStatus: logger.warning,
+        MaintenanceStatus: logger.info,
+        WaitingStatus: logger.info,
+    }
+
+    log_destination_map[type(status)](status.message)

--- a/tests/unit/test_status_handling.py
+++ b/tests/unit/test_status_handling.py
@@ -1,13 +1,24 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 from contextlib import nullcontext
+from unittest.mock import MagicMock
 
 import pytest
-from ops.model import BlockedStatus, WaitingStatus
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    StatusBase,
+    WaitingStatus,
+)
 
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
-from charmed_kubeflow_chisme.status_handling import get_first_worst_error
+from charmed_kubeflow_chisme.status_handling import (
+    get_first_worst_error,
+    set_and_log_status,
+)
 
 BlockedError1 = ErrorWithStatus("Blocked1", BlockedStatus)
 BlockedError2 = ErrorWithStatus("Blocked2", BlockedStatus)
@@ -38,3 +49,23 @@ def test_get_first_worst_error(errors, expected_returned_error, context_raised):
     with context_raised:
         error = get_first_worst_error(errors=errors)
         assert error == expected_returned_error
+
+
+@pytest.mark.parametrize(
+    "type, message, expected_level",
+    [
+        (ActiveStatus, "ActiveStatus, we should log.info!", "INFO"),
+        (BlockedStatus, "BlockedStatus, we should log.warning!", "WARNING"),
+        (MaintenanceStatus, "MaintenanceStatus, we should log.info", "INFO"),
+        (WaitingStatus, "WaitingStatus, we should log.info!", "INFO"),
+    ],
+)
+def test_set_and_log_status(type: StatusBase, message: str, expected_level: str, caplog):
+    mock_unit = MagicMock()
+    logger = logging.getLogger()
+    status = type(message)
+    set_and_log_status(mock_unit, logger, status)
+
+    assert mock_unit.status == status
+    assert [message] == [rec.message for rec in caplog.records]
+    assert [expected_level] == [rec.levelname for rec in caplog.records]


### PR DESCRIPTION
- Add a set_and_log_status(unit, logger, status) function to set and log changes  in the unit's status. This function was initially introduced in [istio-pilot charm](https://github.com/canonical/istio-operators/blob/047ed3513e2098560da7cfd4f10b01f6495c54e7/charms/istio-pilot/src/charm.py#L724-L741).
- Unit test the function

Note that there was the argument that logging the status' history is something we shouldn't do and that should be handled by `Juju` itself but ATM this is not happening. 
