### PR TITLE
feat: use ops's new collect-status event for final status handling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     deepdiff<=6.2.1
     jinja2
     lightkube > 0.10.0
-    ops > 1.2.0
+    ops > 2.5.0
     serialized-data-interface
     ruamel.yaml
     tenacity

--- a/src/charmed_kubeflow_chisme/components/charm_reconciler.py
+++ b/src/charmed_kubeflow_chisme/components/charm_reconciler.py
@@ -147,6 +147,16 @@ class CharmReconciler(Object):
 
         self._charm.framework.observe(self._charm.on.update_status, self.update_status)
 
+        self.framework.observe(self._charm.on.collect_unit_status, self.on_collect_status)
+
+    def on_collect_status(self, event):
+        """Push the status of all components to the ops framework status pool."""
+        statuses = self._get_component_statuses()
+        for name, status in statuses:
+            this_status = add_prefix_to_status(name, status)
+            logger.info(f"Adding status to event.add_status: {this_status}")
+            event.add_status(this_status)
+
     def remove(self, event: EventBase):
         """Runs Component.remove for all components.
 


### PR DESCRIPTION
This uses the collect-status event, implemented in ops 2.5, to set the charm's status on exit of any events.  This sits alongside the regular status pool - the status pool is still used internally in the charm, but the final status is set through the collect-status mechanism.

This is a prototype and may need more thought/testing, but after initial testing of config-changed and update-status events seems like it works great!