### PR TITLE
fix `Prioritizer` to avoid setting `UnknownStatus` when empty

### DIFF
--- a/src/charmed_kubeflow_chisme/components/charm_reconciler.py
+++ b/src/charmed_kubeflow_chisme/components/charm_reconciler.py
@@ -218,9 +218,6 @@ class CharmReconciler(Object):
         By default, if this CharmReconciler has no components then it is active.
         """
         statuses = self._get_component_statuses()
-        print("##########################")
-        print(len(self._component_graph))
-        print("##########################")
         if len(self._component_graph) == 0:
             # If we have nothing to be inactive, we are active.
             self._charm.unit.status = ActiveStatus()

--- a/src/charmed_kubeflow_chisme/components/charm_reconciler.py
+++ b/src/charmed_kubeflow_chisme/components/charm_reconciler.py
@@ -4,7 +4,14 @@
 import logging
 from typing import List, Optional, Tuple
 
-from ops import CharmBase, EventBase, MaintenanceStatus, Object, StatusBase
+from ops import (
+    ActiveStatus,
+    CharmBase,
+    EventBase,
+    MaintenanceStatus,
+    Object,
+    StatusBase,
+)
 
 from ..status_handling.multistatus import add_prefix_to_status
 from .component import Component
@@ -207,8 +214,18 @@ class CharmReconciler(Object):
         """Computes Component statuses, updating the attached Charm's with the aggregate status.
 
         Also logs the full status details to the charm logs.
+
+        By default, if this CharmReconciler has no components then it is active.
         """
         statuses = self._get_component_statuses()
+        print("##########################")
+        print(len(self._component_graph))
+        print("##########################")
+        if len(self._component_graph) == 0:
+            # If we have nothing to be inactive, we are active.
+            self._charm.unit.status = ActiveStatus()
+            return
+
         log_component_statuses(statuses, logger)
 
         # Set the charm status to the worst of all statuses

--- a/src/charmed_kubeflow_chisme/components/component_graph.py
+++ b/src/charmed_kubeflow_chisme/components/component_graph.py
@@ -23,6 +23,10 @@ class ComponentGraph:
         self.component_items: dict[str, ComponentGraphItem] = {}
         self.status_prioritiser = Prioritiser()
 
+    def __len__(self) -> int:
+        """Returns the number of component_items we have."""
+        return len(self.component_items)
+
     def add(
         self,
         component: Component,


### PR DESCRIPTION
The status prioritizer previously would report an UnknownStatus when it had no components to report statuses.  UnknownStatus is a readonly status in Juju so this is not appropriate.  This commit changes Prioritizer to identify when it has no components and instead return ActiveStatus (since a Prioritizer without anything is effectively Active).