### PR TITLE
fix isort line_length setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ line-length = 99
 target-version = ["py38"]
 
 [tool.isort]
+line_length = 99
 profile = "black"
 
 # Linting tools configuration

--- a/src/charmed_kubeflow_chisme/components/__init__.py
+++ b/src/charmed_kubeflow_chisme/components/__init__.py
@@ -9,11 +9,7 @@ from .component_graph_item import ComponentGraphItem
 from .kubernetes_component import KubernetesComponent
 from .leadership_gate_component import LeadershipGateComponent
 from .model_name_gate_component import ModelNameGateComponent
-from .pebble_component import (
-    ContainerFileTemplate,
-    PebbleComponent,
-    PebbleServiceComponent,
-)
+from .pebble_component import ContainerFileTemplate, PebbleComponent, PebbleServiceComponent
 from .serialised_data_interface_components import (
     SdiRelationBroadcasterComponent,
     SdiRelationDataReceiverComponent,

--- a/src/charmed_kubeflow_chisme/components/charm_reconciler.py
+++ b/src/charmed_kubeflow_chisme/components/charm_reconciler.py
@@ -4,14 +4,7 @@
 import logging
 from typing import List, Optional, Tuple
 
-from ops import (
-    ActiveStatus,
-    CharmBase,
-    EventBase,
-    MaintenanceStatus,
-    Object,
-    StatusBase,
-)
+from ops import ActiveStatus, CharmBase, EventBase, MaintenanceStatus, Object, StatusBase
 
 from ..status_handling.multistatus import add_prefix_to_status
 from .component import Component

--- a/src/charmed_kubeflow_chisme/components/component_graph.py
+++ b/src/charmed_kubeflow_chisme/components/component_graph.py
@@ -2,9 +2,7 @@
 # See LICENSE file for licensing details.
 """A collection of ComponentGraphItems that keeps their order."""
 
-from __future__ import (
-    annotations,  # To enable type hinting a method in a class with its own class
-)
+from __future__ import annotations  # To enable type hinting a method in a class with its own class
 
 from typing import Iterable, List, Optional
 

--- a/src/charmed_kubeflow_chisme/components/component_graph_item.py
+++ b/src/charmed_kubeflow_chisme/components/component_graph_item.py
@@ -2,9 +2,7 @@
 # See LICENSE file for licensing details.
 """A wrapper around a Component for use in a ComponentGraph."""
 
-from __future__ import (
-    annotations,  # To enable type hinting a method in a class with its own class
-)
+from __future__ import annotations  # To enable type hinting a method in a class with its own class
 
 import logging
 from typing import List, Optional

--- a/src/charmed_kubeflow_chisme/kubernetes/__init__.py
+++ b/src/charmed_kubeflow_chisme/kubernetes/__init__.py
@@ -4,9 +4,6 @@
 """Helpers for interacting with Kubernetes."""
 
 from ._check_resources import check_resources
-from ._kubernetes_resource_handler import (
-    KubernetesResourceHandler,
-    create_charm_default_labels,
-)
+from ._kubernetes_resource_handler import KubernetesResourceHandler, create_charm_default_labels
 
 __all__ = [check_resources, create_charm_default_labels, KubernetesResourceHandler]

--- a/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
+++ b/src/charmed_kubeflow_chisme/kubernetes/_kubernetes_resource_handler.py
@@ -14,11 +14,7 @@ from ops.model import ActiveStatus, BlockedStatus
 from ..exceptions import ErrorWithStatus
 from ..lightkube.batch import apply_many, delete_many
 from ..status_handling import get_first_worst_error
-from ..types import (
-    LightkubeResourcesList,
-    LightkubeResourceType,
-    LightkubeResourceTypesSet,
-)
+from ..types import LightkubeResourcesList, LightkubeResourceType, LightkubeResourceTypesSet
 from ..types._charm_status import AnyCharmStatus
 from ._check_resources import check_resources
 

--- a/src/charmed_kubeflow_chisme/types/__init__.py
+++ b/src/charmed_kubeflow_chisme/types/__init__.py
@@ -4,11 +4,7 @@
 """Reusable typing definitions, useful for adding type hints."""
 
 from ._charm_status import CharmStatusType
-from ._lightkube import (
-    LightkubeResourcesList,
-    LightkubeResourceType,
-    LightkubeResourceTypesSet,
-)
+from ._lightkube import LightkubeResourcesList, LightkubeResourceType, LightkubeResourceTypesSet
 
 __all__ = [
     CharmStatusType,

--- a/tests/unit/components/test_charm_reconciler.py
+++ b/tests/unit/components/test_charm_reconciler.py
@@ -3,11 +3,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from fixtures import (  # noqa: F401
-    MinimallyBlockedComponent,
-    MinimallyExtendedComponent,
-    harness,
-)
+from fixtures import MinimallyBlockedComponent, MinimallyExtendedComponent, harness  # noqa: F401
 from ops import ActiveStatus, BlockedStatus, WaitingStatus
 
 from charmed_kubeflow_chisme.components.charm_reconciler import CharmReconciler

--- a/tests/unit/components/test_component_graph.py
+++ b/tests/unit/components/test_component_graph.py
@@ -2,11 +2,7 @@
 # See LICENSE file for licensing details.
 
 import pytest
-from fixtures import (  # noqa: F401
-    MinimallyBlockedComponent,
-    MinimallyExtendedComponent,
-    harness,
-)
+from fixtures import MinimallyBlockedComponent, MinimallyExtendedComponent, harness  # noqa: F401
 from ops import BlockedStatus, UnknownStatus
 
 from charmed_kubeflow_chisme.components.component_graph import ComponentGraph

--- a/tests/unit/test_kubernetes.py
+++ b/tests/unit/test_kubernetes.py
@@ -8,10 +8,7 @@ from typing import NamedTuple
 from unittest import mock
 
 import pytest
-from lightkube.generic_resource import (
-    create_global_resource,
-    create_namespaced_resource,
-)
+from lightkube.generic_resource import create_global_resource, create_namespaced_resource
 from lightkube.models.apps_v1 import StatefulSetSpec, StatefulSetStatus
 from lightkube.models.core_v1 import PodTemplateSpec
 from lightkube.models.meta_v1 import LabelSelector, ObjectMeta
@@ -36,9 +33,7 @@ from charmed_kubeflow_chisme.kubernetes._kubernetes_resource_handler import (
     _validate_resources,
     codecs,
 )
-from charmed_kubeflow_chisme.kubernetes._validate_statefulset import (
-    validate_statefulset,
-)
+from charmed_kubeflow_chisme.kubernetes._validate_statefulset import validate_statefulset
 from charmed_kubeflow_chisme.lightkube.mocking import FakeApiError
 
 data_dir = Path(__file__).parent.joinpath("data")

--- a/tests/unit/test_status_handling.py
+++ b/tests/unit/test_status_handling.py
@@ -6,19 +6,10 @@ from contextlib import nullcontext
 from unittest.mock import MagicMock
 
 import pytest
-from ops.model import (
-    ActiveStatus,
-    BlockedStatus,
-    MaintenanceStatus,
-    StatusBase,
-    WaitingStatus,
-)
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, StatusBase, WaitingStatus
 
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
-from charmed_kubeflow_chisme.status_handling import (
-    get_first_worst_error,
-    set_and_log_status,
-)
+from charmed_kubeflow_chisme.status_handling import get_first_worst_error, set_and_log_status
 
 BlockedError1 = ErrorWithStatus("Blocked1", BlockedStatus)
 BlockedError2 = ErrorWithStatus("Blocked2", BlockedStatus)


### PR DESCRIPTION
Previously, isort was using its default line_length=79, whereas all other linting was done with line_length=99.  This commit fixes the setting and reformates any files affected.