### PR TITLE
feat: Add fire_update_status()

### DIFF
--- a/src/charmed_kubeflow_chisme/testing/__init__.py
+++ b/src/charmed_kubeflow_chisme/testing/__init__.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 """Utilities for testing charms."""
 
+from ._fire_update_status_to_unit import fire_update_status_to_unit
 from .serialized_data_interface import (
     RelationMetadata,
     add_data_to_sdi_relation,
@@ -12,4 +13,5 @@ __all__ = [
     RelationMetadata,
     add_data_to_sdi_relation,
     add_sdi_relation_to_harness,
+    fire_update_status_to_unit,
 ]

--- a/src/charmed_kubeflow_chisme/testing/_fire_update_status_to_unit.py
+++ b/src/charmed_kubeflow_chisme/testing/_fire_update_status_to_unit.py
@@ -1,0 +1,28 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import subprocess
+
+
+def fire_update_status_to_unit(unit_name: str, model_name: str):
+    """Fire an update-status to unit_name unit.
+
+    This was generated using `jhack fire foo/0 update-status --dry-run`.
+
+    Args:
+        unit_name: The name of the unit to fire an update_status to e.g. foo/0
+        model_name: The name of the model where unit is deployed
+    """
+    subprocess.Popen(
+        [
+            "juju",
+            "ssh",
+            unit_name,
+            "/usr/bin/juju-exec",
+            "-u",
+            unit_name,
+            "JUJU_DISPATCH_PATH=hooks/update-status",
+            f"JUJU_MODEL_NAME={model_name}",
+            f"JUJU_UNIT_NAME={unit_name}",
+            "./dispatch",
+        ]
+    )


### PR DESCRIPTION
Add function to fire an update-status to unit_name unit in model model_name. This was generated using `jhack fire foo/0 update-status --dry-run`.