### PR TITLE
add pebble_components.LazyContainerFileTemplate

### DIFF
--- a/src/charmed_kubeflow_chisme/components/__init__.py
+++ b/src/charmed_kubeflow_chisme/components/__init__.py
@@ -9,7 +9,12 @@ from .component_graph_item import ComponentGraphItem
 from .kubernetes_component import KubernetesComponent
 from .leadership_gate_component import LeadershipGateComponent
 from .model_name_gate_component import ModelNameGateComponent
-from .pebble_component import ContainerFileTemplate, PebbleComponent, PebbleServiceComponent
+from .pebble_component import (
+    ContainerFileTemplate,
+    LazyContainerFileTemplate,
+    PebbleComponent,
+    PebbleServiceComponent,
+)
 from .serialised_data_interface_components import (
     SdiRelationBroadcasterComponent,
     SdiRelationDataReceiverComponent,
@@ -24,6 +29,7 @@ __all__ = [
     LeadershipGateComponent,
     ModelNameGateComponent,
     ContainerFileTemplate,
+    LazyContainerFileTemplate,
     PebbleComponent,
     PebbleServiceComponent,
     SdiRelationBroadcasterComponent,

--- a/src/charmed_kubeflow_chisme/components/pebble_component.py
+++ b/src/charmed_kubeflow_chisme/components/pebble_component.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class LazyContainerFileTemplate:
-    """A lazy container file template that can be rendered and pushed into a Pebble container."""
+    """A lazy file template renderer for use in pushing files to a Pebble container."""
 
     def __init__(
         self,
@@ -28,7 +28,32 @@ class LazyContainerFileTemplate:
         group: Optional[str] = None,
         permissions: Optional[str] = None,
     ):
-        """A ContainerFileTemplate that lazily generates its template from a path or string."""
+        """A lazy file template renderer for use in pushing files to a Pebble container.
+
+        This generates a file from a template provided as a string or a file path.  The file will
+        be rendered with a context provided as a dict.
+
+        source_template_path, source_template, and context can also be provided as callables that
+        return the appropriate value.  This allows for lazy evaluation of these values, which can
+        be useful for using in charm Components.
+
+        Args:
+            destination_path: The path to the file in the container.
+            source_template_path: The path to the source template file.
+                                  Can be provided as a Path, str, or a function that returns
+                                  either.
+                                  Only one of source_template_path or source_template can be set.
+            source_template: The source template string.  Only one of source_template_path or this
+                             can be set.
+                             Can be provided as a str or a function that returns a str.
+            context: A dict of context for rendering the file.  Leave this as None or {} if the
+                     template does not need rendering.
+                     Can be also be provided as a function returning a dict so the input can be
+                     lazily evaluated.
+            user: The user to own the file in the container.
+            group: The group to own the file in the container.
+            permissions: The permissions to set on the file in the container.
+        """
         if source_template_path is not None and source_template is not None:
             raise ValueError("Only one of source_template_path or source_template can be set.")
         elif source_template_path is None and source_template is None:
@@ -90,7 +115,7 @@ class LazyContainerFileTemplate:
 
 
 class ContainerFileTemplate(LazyContainerFileTemplate):
-    """A container file template that can be rendered and pushed into a Pebble container."""
+    """A file template renderer for use in pushing files to a Pebble container."""
 
     def __init__(
         self,
@@ -103,9 +128,33 @@ class ContainerFileTemplate(LazyContainerFileTemplate):
     ):
         """Defines a file template that should be rendered and pushed into a Pebble container.
 
+        This generates a file from a template provided as a file path.  The file will
+        be rendered with a context provided as a dict.
+
+        source_template_path and context_function can also be provided as callables that return the
+        appropriate value.  This allows for lazy evaluation of these values, which can be useful
+        for using in charm Components.
+
         This is a backwards-compatible refactor of the original ContainerFileTemplate using
         LazyContainerFileTemplate as the backend implementation.  This was introduced because
-        LazyContainerFileTemplate introduced a breaking change in the API.
+        ContainerFileTemplate had two required arguments, source_template_path and
+        destination_path, whereas LazyContainerFileTemplate only requires destination_path.  This
+        forced the order of the arguments to be changed, which is a breaking change in the API.
+
+        Args:
+            destination_path: The path to the file in the container.
+            source_template_path: The path to the source template file.
+                                  Can be provided as a Path, str, or a function that returns
+                                  either.
+                                  Only one of source_template_path or source_template can be set.
+            context_function: A dict of context for rendering the file.  Leave this as None or {}
+                              if the
+                              template does not need rendering.
+                              Can be also be provided as a function returning a dict so the input
+                              can be lazily evaluated.
+            user: The user to own the file in the container.
+            group: The group to own the file in the container.
+            permissions: The permissions to set on the file in the container.
         """
         if context_function is None:
 

--- a/src/charmed_kubeflow_chisme/components/pebble_component.py
+++ b/src/charmed_kubeflow_chisme/components/pebble_component.py
@@ -92,7 +92,7 @@ class LazyContainerFileTemplate:
         """Returns a dict of the inputs expected by ops.model.Container.push()."""
         return dict(
             path=self.destination_path,
-            source=self.render(),
+            source=self.render_source_template(),
             user=self.user,
             group=self.group,
             permissions=self.permissions,
@@ -106,7 +106,7 @@ class LazyContainerFileTemplate:
         else:
             return self.source_template
 
-    def render(self):
+    def render_source_template(self):
         """Renders the source template with the given context, returning as a string."""
         source_template = self.get_source_template()
         template = jinja2.Template(source_template)

--- a/src/charmed_kubeflow_chisme/components/pebble_component.py
+++ b/src/charmed_kubeflow_chisme/components/pebble_component.py
@@ -43,9 +43,9 @@ class LazyContainerFileTemplate:
                                   Can be provided as a Path, str, or a function that returns
                                   either.
                                   Only one of source_template_path or source_template can be set.
-            source_template: The source template string.  Only one of source_template_path or this
-                             can be set.
+            source_template: The source template string.
                              Can be provided as a str or a function that returns a str.
+                             Only one of source_template_path or this can be set.
             context: A dict of context for rendering the file.  Leave this as None or {} if the
                      template does not need rendering.
                      Can be also be provided as a function returning a dict so the input can be

--- a/src/charmed_kubeflow_chisme/components/pebble_component.py
+++ b/src/charmed_kubeflow_chisme/components/pebble_component.py
@@ -197,7 +197,9 @@ class PebbleComponent(Component):
         name: str,
         container_name: str,
         *args,
-        files_to_push: Optional[List[ContainerFileTemplate]] = None,
+        files_to_push: Optional[
+            List[Union[ContainerFileTemplate, LazyContainerFileTemplate]]
+        ] = None,
         **kwargs,
     ):
         """Instantiate the PebbleComponent.
@@ -207,8 +209,9 @@ class PebbleComponent(Component):
             name: Name of this component
             container_name: Name of this container.  Note that this name is also used as the
                             parent object's Component.name parameter.
-            files_to_push: Optional List of ContainerFile objects that define templates to be
-                           rendered and pushed into the container as files
+            files_to_push: Optional List of LazyContainerFileTemplate or ContainerFileTemplate
+                           objects that define templates to be rendered and pushed into the
+                           container as files
         """
         super().__init__(charm, name, *args, **kwargs)
         self.container_name = container_name

--- a/tests/unit/components/test_pebble_component.py
+++ b/tests/unit/components/test_pebble_component.py
@@ -399,7 +399,7 @@ class TestLazyContainerFileTemplate:
             permissions="permissions",
         )
 
-        assert cft.render() == expected
+        assert cft.render_source_template() == expected
 
     def test_get_inputs_for_push(self):
         """Tests get_inputs_for_push returns the expected inputs."""

--- a/tests/unit/components/test_pebble_component.py
+++ b/tests/unit/components/test_pebble_component.py
@@ -1,10 +1,10 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-
+import tempfile
 from pathlib import Path
 from unittest import mock
 
-from charmed_kubeflow_chisme.components import ContainerFileTemplate
+import pytest
 from fixtures import (  # noqa: F401
     MinimalPebbleComponent,
     MinimalPebbleServiceComponent,
@@ -13,6 +13,7 @@ from fixtures import (  # noqa: F401
 from ops import ActiveStatus, WaitingStatus
 
 import charmed_kubeflow_chisme.components.pebble_component
+from charmed_kubeflow_chisme.components import ContainerFileTemplate, LazyContainerFileTemplate
 
 
 class TestPebbleComponent:
@@ -250,3 +251,152 @@ class TestContainerFileTemplate:
         assert cft.user == user
         assert cft.group == group
         assert cft.permissions == permissions
+
+
+class TestLazyContainerFileTemplate:
+    def test_static_inputs(self):
+        """Tests that the LazyContainerFileTemplate can accept static inputs."""
+        destination_path = "destination_path"
+        source_template_path = "source_template_path"
+        context = {"key": "value"}
+        user = "user"
+        group = "group"
+        permissions = "permissions"
+
+        # Test these without using kwargs to ensure they API doesn't change
+        cft = LazyContainerFileTemplate(
+            destination_path,
+            source_template_path=source_template_path,
+            context=context,
+            user=user,
+            group=group,
+            permissions=permissions,
+        )
+
+        assert cft.destination_path == Path(destination_path)
+        assert cft.source_template_path == Path(source_template_path)
+        assert cft.context == context
+        assert cft.user == user
+        assert cft.group == group
+        assert cft.permissions == permissions
+
+    def test_lazy_inputs(self):
+        """Tests that the LazyContainerFileTemplate can accept lazy inputs."""
+        destination_path = "destination_path"
+        source_template_path = "source_template_path"
+        context = {"key": "value"}
+        user = "user"
+        group = "group"
+        permissions = "permissions"
+
+        # Test these without using kwargs to ensure they API doesn't change
+        cft = LazyContainerFileTemplate(
+            destination_path,
+            source_template_path=lambda: source_template_path,
+            context=lambda: context,
+            user=user,
+            group=group,
+            permissions=permissions,
+        )
+
+        assert cft.destination_path == Path(destination_path)
+        assert cft.source_template_path == Path(source_template_path)
+        assert cft.context == context
+        assert cft.user == user
+        assert cft.group == group
+        assert cft.permissions == permissions
+
+    @pytest.mark.parametrize(
+        "source_template, source_template_path",
+        [
+            (None, None),
+            ("not none", "not none"),
+        ],
+    )
+    def test_requires_exactly_one_of_source_template_and_source_template_path(
+        self, source_template, source_template_path
+    ):
+        """Tests LazyContainerFileTemplate requires one of source_template/source_template_path."""
+        with pytest.raises(ValueError):
+            LazyContainerFileTemplate(
+                "destination_path",
+                source_template_path=source_template_path,
+                source_template=source_template,
+                context={},
+                user="user",
+                group="group",
+                permissions="permissions",
+            )
+
+    def test_get_source_template_given_source_template(self):
+        """Tests get_source_template returns the expected value when provided source_template."""
+        source_template = "source_template"
+        cft = LazyContainerFileTemplate(
+            "destination_path",
+            source_template=source_template,
+            context={},
+            user="user",
+            group="group",
+            permissions="permissions",
+        )
+
+        assert cft.get_source_template() == source_template
+
+    def test_get_source_template_given_source_template_file(self):
+        """Tests get_source_template returns expected value when provided source_template_file."""
+        source_template = "source_template"
+        with tempfile.NamedTemporaryFile() as f:
+            f.write(source_template.encode())
+            # Ensure the text is written to the file and not kept buffered
+            f.flush()
+            cft = LazyContainerFileTemplate(
+                "destination_path",
+                source_template_path=f.name,
+                context={},
+                user="user",
+                group="group",
+                permissions="permissions",
+            )
+
+            assert cft.get_source_template() == source_template
+
+    def test_render(self):
+        """Tests render given a source_template and context."""
+        source_template = "unrendered {{ key }} template"
+        expected = "unrendered value template"
+        cft = LazyContainerFileTemplate(
+            "destination_path",
+            source_template=source_template,
+            context={"key": "value"},
+            user="user",
+            group="group",
+            permissions="permissions",
+        )
+
+        assert cft.render() == expected
+
+    def test_get_inputs_for_push(self):
+        """Tests get_inputs_for_push returns the expected inputs."""
+        source_template = "unrendered {{ key }} template"
+        expected_rendered = "unrendered value template"
+        user = "user"
+        group = "group"
+        permissions = "permissions"
+        cft = LazyContainerFileTemplate(
+            "destination_path",
+            source_template=source_template,
+            context={"key": "value"},
+            user=user,
+            group=group,
+            permissions=permissions,
+        )
+        expected = {
+            "path": Path("destination_path"),
+            "source": expected_rendered,
+            "user": user,
+            "group": group,
+            "permissions": permissions,
+            "make_dirs": True,
+        }
+
+        assert cft.get_inputs_for_push() == expected

--- a/tests/unit/components/test_pebble_component.py
+++ b/tests/unit/components/test_pebble_component.py
@@ -280,8 +280,8 @@ class TestLazyContainerFileTemplate:
         assert cft.group == group
         assert cft.permissions == permissions
 
-    def test_lazy_inputs(self):
-        """Tests that the LazyContainerFileTemplate can accept lazy inputs."""
+    def test_lazy_inputs_with_source_template_path(self):
+        """Tests that LazyContainerFileTemplate accepts lazy inputs and source_template_path."""
         destination_path = "destination_path"
         source_template_path = "source_template_path"
         context = {"key": "value"}
@@ -301,6 +301,32 @@ class TestLazyContainerFileTemplate:
 
         assert cft.destination_path == Path(destination_path)
         assert cft.source_template_path == Path(source_template_path)
+        assert cft.context == context
+        assert cft.user == user
+        assert cft.group == group
+        assert cft.permissions == permissions
+
+    def test_lazy_inputs_with_source_template(self):
+        """Tests that LazyContainerFileTemplate accepts lazy inputs and source_template."""
+        destination_path = "destination_path"
+        source_template = "source_template"
+        context = {"key": "value"}
+        user = "user"
+        group = "group"
+        permissions = "permissions"
+
+        # Test these without using kwargs to ensure they API doesn't change
+        cft = LazyContainerFileTemplate(
+            destination_path,
+            source_template=lambda: source_template,
+            context=lambda: context,
+            user=user,
+            group=group,
+            permissions=permissions,
+        )
+
+        assert cft.destination_path == Path(destination_path)
+        assert cft.source_template == source_template
         assert cft.context == context
         assert cft.user == user
         assert cft.group == group

--- a/tests/unit/components/test_pebble_component.py
+++ b/tests/unit/components/test_pebble_component.py
@@ -1,8 +1,10 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from pathlib import Path
 from unittest import mock
 
+from charmed_kubeflow_chisme.components import ContainerFileTemplate
 from fixtures import (  # noqa: F401
     MinimalPebbleComponent,
     MinimalPebbleServiceComponent,
@@ -194,3 +196,57 @@ class TestPebbleServiceComponent:
         status = pc.status
 
         assert isinstance(status, ActiveStatus)
+
+
+class TestContainerFileTemplate:
+    def test_static_inputs(self):
+        """Tests that the ContainerFileTemplate can accept static inputs."""
+        source_template_path = "source_template_path"
+        destination_path = "destination_path"
+        context = {"key": "value"}
+        user = "user"
+        group = "group"
+        permissions = "permissions"
+
+        # Test these without using kwargs to ensure they API doesn't change
+        cft = ContainerFileTemplate(
+            source_template_path,
+            destination_path,
+            context_function=context,
+            user=user,
+            group=group,
+            permissions=permissions,
+        )
+
+        assert cft.destination_path == Path(destination_path)
+        assert cft.source_template_path == Path(source_template_path)
+        assert cft.context_function() == context
+        assert cft.user == user
+        assert cft.group == group
+        assert cft.permissions == permissions
+
+    def test_lazy_inputs(self):
+        """Tests that the ContainerFileTemplate can accept lazy inputs."""
+        source_template_path = "source_template_path"
+        destination_path = "destination_path"
+        context = {"key": "value"}
+        user = "user"
+        group = "group"
+        permissions = "permissions"
+
+        # Test these without using kwargs to ensure they API doesn't change
+        cft = ContainerFileTemplate(
+            source_template_path,
+            destination_path,
+            lambda: context,
+            user,
+            group,
+            permissions,
+        )
+
+        assert cft.destination_path == Path(destination_path)
+        assert cft.source_template_path == Path(source_template_path)
+        assert cft.context_function() == context
+        assert cft.user == user
+        assert cft.group == group
+        assert cft.permissions == permissions


### PR DESCRIPTION
adds a lazy-rendering version of the ContainerFileTemplate to allow for inputs to be passed as callables rather than literal values.  

Closes #89

Since this introduces a `LazyContainerFileTemplate` and then modifies the previous `ContainerFileTemplate` to use the new lazy version as a backend, there's a chance of regressions that break the original `ContainerFileTemplate`.  Tests for this were added, and [this pvcviewer draft PR](https://github.com/canonical/pvcviewer-operator/pull/30) was created to regression test this chisme PR branch.