### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,6 @@ jobs:
           provider: microk8s
           channel: 1.29-strict/stable
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
       - name: Run integration tests
         run: tox -vve integration


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944