### PR TITLE
chore: bump version to 0.4.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = charmed-kubeflow-chisme
-version = 0.4.3
+version = 0.4.4
 author = Charmed Kubeflow
 description = A collection of helpers for Charms maintained by the Charmed Kubeflow team
 long_description = file: README.md


### PR DESCRIPTION
Release 0.4.4 with changes:
* https://github.com/canonical/charmed-kubeflow-chisme/pull/124
* https://github.com/canonical/charmed-kubeflow-chisme/pull/121