### PR TITLE
Add more events to PebbleServiceComponent

### DIFF
--- a/src/charmed_kubeflow_chisme/components/__init__.py
+++ b/src/charmed_kubeflow_chisme/components/__init__.py
@@ -14,6 +14,7 @@ from .pebble_component import (
     LazyContainerFileTemplate,
     PebbleComponent,
     PebbleServiceComponent,
+    get_event_from_charm,
 )
 from .serialised_data_interface_components import (
     SdiRelationBroadcasterComponent,
@@ -34,4 +35,5 @@ __all__ = [
     PebbleServiceComponent,
     SdiRelationBroadcasterComponent,
     SdiRelationDataReceiverComponent,
+    get_event_from_charm,
 ]

--- a/src/charmed_kubeflow_chisme/components/pebble_component.py
+++ b/src/charmed_kubeflow_chisme/components/pebble_component.py
@@ -342,6 +342,7 @@ class PebbleServiceComponent(PebbleComponent):
             )
         return ActiveStatus()
 
+
 def get_event_from_charm(charm: CharmBase, container_name: str, event_name: str) -> str:
     """Returns an event with a specified name for a given container_name."""
     prefix = container_name.replace("-", "_")

--- a/src/charmed_kubeflow_chisme/components/pebble_component.py
+++ b/src/charmed_kubeflow_chisme/components/pebble_component.py
@@ -221,7 +221,6 @@ class PebbleComponent(Component):
             get_event_from_charm(self._charm, self.container_name, "pebble_ready"),
             get_event_from_charm(self._charm, self.container_name, "pebble_check_failed"),
             get_event_from_charm(self._charm, self.container_name, "pebble_check_recovered"),
-            get_event_from_charm(self._charm, self.container_name, "pebble_custom_notice"),
         ]
         self._files_to_push = files_to_push or []
 

--- a/src/charmed_kubeflow_chisme/components/pebble_component.py
+++ b/src/charmed_kubeflow_chisme/components/pebble_component.py
@@ -218,7 +218,10 @@ class PebbleComponent(Component):
         # TODO: Should a PebbleComponent automatically be subscribed to this event?  Or just
         #  a PebbleServiceComponent?
         self._events_to_observe: List[str] = [
-            get_pebble_ready_event_from_charm(self._charm, self.container_name)
+            get_event_from_charm(self._charm, self.container_name, "pebble_ready"),
+            get_event_from_charm(self._charm, self.container_name, "pebble_check_failed"),
+            get_event_from_charm(self._charm, self.container_name, "pebble_check_recovered"),
+            get_event_from_charm(self._charm, self.container_name, "pebble_custom_notice")
         ]
         self._files_to_push = files_to_push or []
 
@@ -339,9 +342,8 @@ class PebbleServiceComponent(PebbleComponent):
             )
         return ActiveStatus()
 
-
-def get_pebble_ready_event_from_charm(charm: CharmBase, container_name: str) -> str:
-    """Returns the pebble-ready event for a given container_name."""
+def get_event_from_charm(charm: CharmBase, container_name: str, event_name: str) -> str:
+    """Returns an event with a specified name for a given container_name."""
     prefix = container_name.replace("-", "_")
-    event_name = f"{prefix}_pebble_ready"
-    return getattr(charm.on, event_name)
+    container_event_name = f"{prefix}_{event_name}"
+    return getattr(charm.on, container_event_name)

--- a/src/charmed_kubeflow_chisme/components/pebble_component.py
+++ b/src/charmed_kubeflow_chisme/components/pebble_component.py
@@ -221,7 +221,7 @@ class PebbleComponent(Component):
             get_event_from_charm(self._charm, self.container_name, "pebble_ready"),
             get_event_from_charm(self._charm, self.container_name, "pebble_check_failed"),
             get_event_from_charm(self._charm, self.container_name, "pebble_check_recovered"),
-            get_event_from_charm(self._charm, self.container_name, "pebble_custom_notice")
+            get_event_from_charm(self._charm, self.container_name, "pebble_custom_notice"),
         ]
         self._files_to_push = files_to_push or []
 

--- a/tests/unit/components/test_pebble_component.py
+++ b/tests/unit/components/test_pebble_component.py
@@ -10,7 +10,7 @@ from fixtures import (  # noqa: F401
     MinimalPebbleServiceComponent,
     harness_with_container,
 )
-from ops import ActiveStatus, WaitingStatus
+from ops import ActiveStatus, BoundEvent, WaitingStatus
 
 import charmed_kubeflow_chisme.components.pebble_component
 from charmed_kubeflow_chisme.components import (
@@ -36,6 +36,21 @@ class TestPebbleComponent:
             harness_with_container.charm, self.container_name, event_type
         )
         assert result == mock_event_value
+
+    def test_get_pebble_events(self, harness_with_container):
+        """Test that all pebble events do exist in the container."""
+        pebble_ready_event = get_event_from_charm(
+            harness_with_container.charm, self.container_name, "pebble_ready"
+        )
+        pebble_check_recovered_event = get_event_from_charm(
+            harness_with_container.charm, self.container_name, "pebble_check_failed"
+        )
+        pebble_check_failed_event = get_event_from_charm(
+            harness_with_container.charm, self.container_name, "pebble_check_recovered"
+        )
+        assert isinstance(pebble_ready_event, BoundEvent)
+        assert isinstance(pebble_check_recovered_event, BoundEvent)
+        assert isinstance(pebble_check_failed_event, BoundEvent)
 
     def test_ready_for_execution_if_service_up(self, harness_with_container):
         """Test that ready_for_execution returns True if the service is up."""

--- a/tests/unit/components/test_pebble_component.py
+++ b/tests/unit/components/test_pebble_component.py
@@ -1,6 +1,5 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-import logging
 import tempfile
 from pathlib import Path
 from unittest import mock
@@ -17,26 +16,27 @@ import charmed_kubeflow_chisme.components.pebble_component
 from charmed_kubeflow_chisme.components import (
     ContainerFileTemplate,
     LazyContainerFileTemplate,
-    get_event_from_charm
+    get_event_from_charm,
 )
 
-logger = logging.getLogger(__name__)
 
 class TestPebbleComponent:
     name = "test-component"
     container_name = "test-container"
 
     def test_get_event_from_charm(self, harness_with_container):
-        """Test that get_event_from_charm returns the events that we want"""
+        """Test that get_event_from_charm returns the events requested."""
         event_type = "mock_event"
         expected_event_name = "test_container_mock_event"
         mock_event_value = "MockEvent"
-        
+
         setattr(harness_with_container.charm.on, expected_event_name, mock_event_value)
-        
-        result = get_event_from_charm(harness_with_container.charm, self.container_name, event_type)
+
+        result = get_event_from_charm(
+            harness_with_container.charm, self.container_name, event_type
+        )
         assert result == mock_event_value
-    
+
     def test_ready_for_execution_if_service_up(self, harness_with_container):
         """Test that ready_for_execution returns True if the service is up."""
         harness_with_container.set_can_connect(self.container_name, True)
@@ -70,6 +70,7 @@ class TestPebbleComponent:
         )
 
         assert isinstance(pc.status, WaitingStatus)
+
 
 class TestPebbleServiceComponent:
     name = "test-component"
@@ -441,4 +442,4 @@ class TestLazyContainerFileTemplate:
             "make_dirs": True,
         }
 
-        assert cft.get_inputs_for_push() == expected    
+        assert cft.get_inputs_for_push() == expected


### PR DESCRIPTION
This PR adds to the list of events that are observed by the `PebbleServiceComponent`. The following events are added:
- [pebble_check_failed](https://ops.readthedocs.io/en/latest/state-transition-testing.html#ops.testing.CharmEvents.pebble_check_failed)
- [pebble_check_recovered](https://ops.readthedocs.io/en/latest/state-transition-testing.html#ops.testing.CharmEvents.pebble_check_recovered)

This will be useful while writing the Github Profiles Automator charm, see https://github.com/canonical/github-profiles-automator/issues/13