### PR TITLE
Add ContainerStringWrapper to handle pushing strings to the container

### DIFF
--- a/src/charmed_kubeflow_chisme/components/__init__.py
+++ b/src/charmed_kubeflow_chisme/components/__init__.py
@@ -11,6 +11,7 @@ from .leadership_gate_component import LeadershipGateComponent
 from .model_name_gate_component import ModelNameGateComponent
 from .pebble_component import (
     ContainerFileTemplate,
+    ContainerStringWrapper,
     LazyContainerFileTemplate,
     PebbleComponent,
     PebbleServiceComponent,
@@ -29,6 +30,7 @@ __all__ = [
     LeadershipGateComponent,
     ModelNameGateComponent,
     ContainerFileTemplate,
+    ContainerStringWrapper,
     LazyContainerFileTemplate,
     PebbleComponent,
     PebbleServiceComponent,

--- a/src/charmed_kubeflow_chisme/components/pebble_component.py
+++ b/src/charmed_kubeflow_chisme/components/pebble_component.py
@@ -26,7 +26,7 @@ class LazyContainerFileTemplate:
         context: Optional[Union[dict, Callable[[], dict]]] = None,
         user: Optional[str] = None,
         group: Optional[str] = None,
-        permissions: Optional[str] = None,
+        permissions: Optional[int] = None,
     ):
         """A lazy file template renderer for use in pushing files to a Pebble container.
 
@@ -124,7 +124,7 @@ class ContainerFileTemplate(LazyContainerFileTemplate):
         context_function: Optional[Union[dict, Callable[[], dict]]] = None,
         user: Optional[str] = None,
         group: Optional[str] = None,
-        permissions: Optional[str] = None,
+        permissions: Optional[int] = None,
     ):
         """Defines a file template that should be rendered and pushed into a Pebble container.
 
@@ -197,7 +197,7 @@ class ContainerStringWrapper:
         source_string: str,
         user: Optional[str] = None,
         group: Optional[str] = None,
-        permissions: Optional[str] = None,
+        permissions: Optional[int] = None,
     ):
         """A simple wrapper for use in pushing files to a Pebble container.
 

--- a/tests/unit/components/test_pebble_component.py
+++ b/tests/unit/components/test_pebble_component.py
@@ -13,7 +13,11 @@ from fixtures import (  # noqa: F401
 from ops import ActiveStatus, WaitingStatus
 
 import charmed_kubeflow_chisme.components.pebble_component
-from charmed_kubeflow_chisme.components import ContainerFileTemplate, LazyContainerFileTemplate
+from charmed_kubeflow_chisme.components import (
+    ContainerFileTemplate,
+    ContainerStringWrapper,
+    LazyContainerFileTemplate,
+)
 
 
 class TestPebbleComponent:
@@ -419,6 +423,57 @@ class TestLazyContainerFileTemplate:
         expected = {
             "path": Path("destination_path"),
             "source": expected_rendered,
+            "user": user,
+            "group": group,
+            "permissions": permissions,
+            "make_dirs": True,
+        }
+
+        assert cft.get_inputs_for_push() == expected
+
+
+class TestContainerStringWrapper:
+    def test_static_inputs(self):
+        """Tests that the ContainerStringWrapper class can accept static inputs."""
+        destination_path = "destination_path"
+        source_string = "source_string"
+        user = "user"
+        group = "group"
+        permissions = "permissions"
+
+        # Test these without using kwargs to ensure they API doesn't change
+        cft = ContainerStringWrapper(
+            destination_path,
+            source_string,
+            user=user,
+            group=group,
+            permissions=permissions,
+        )
+
+        assert cft.destination_path == Path(destination_path)
+        assert cft.source_string == source_string
+        assert cft.user == user
+        assert cft.group == group
+        assert cft.permissions == permissions
+
+    def test_get_inputs_for_push(self):
+        """Tests get_inputs_for_push returns the expected inputs."""
+        destination_path = "destination_path"
+        source_string = "source_string"
+        user = "user"
+        group = "group"
+        permissions = "permissions"
+        
+        cft = ContainerStringWrapper(
+            destination_path,
+            source_string,
+            user=user,
+            group=group,
+            permissions=permissions,
+        )
+        expected = {
+            "path": Path("destination_path"),
+            "source": source_string,
             "user": user,
             "group": group,
             "permissions": permissions,

--- a/tests/unit/components/test_pebble_component.py
+++ b/tests/unit/components/test_pebble_component.py
@@ -463,7 +463,7 @@ class TestContainerStringWrapper:
         user = "user"
         group = "group"
         permissions = "permissions"
-        
+
         cft = ContainerStringWrapper(
             destination_path,
             source_string,


### PR DESCRIPTION
This PR creates a simple class named `ContainerStringWrapper` under `src/chamred_kubeflow_chisme/components/pebble_component`. As the name suggests, it is a simple wrapper for pushing strings to the container that a `PebbleComponent` handles. The reason for adding this is that currently, we can only push files to `PebbleComponent`.

I have also added 2 unit tests under `tests/components/test_pebble_component.py`

Additionally, this changes the `permissions` field of `LazyContainerFileTemplate` and `FileContainerFileTemplate` from `str` to `int`, since this option is passed directly to the [push method](https://ops.readthedocs.io/en/latest/reference/ops.html#ops.Container.push) that uses integers for the permissions.

This new class will be used in the new Github Profile Automator charm, see [this comment](https://github.com/canonical/github-profiles-automator/issues/14#issuecomment-2556903242) for more details.

