### PR TITLE
(chore): Bump version to 0.4.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = charmed-kubeflow-chisme
-version = 0.4.4
+version = 0.4.5
 author = Charmed Kubeflow
 description = A collection of helpers for Charms maintained by the Charmed Kubeflow team
 long_description = file: README.md


### PR DESCRIPTION
Release new patch version `0.4.5`, which add more Pebble events to the list of events that are observed by `PebbleServiceComponent`. The following PRs are introduced:
- https://github.com/canonical/charmed-kubeflow-chisme/pull/130