### PR TITLE
Fix type for `permissions` field in LazyContainerFileTemplate and ContainerFileTemplate

### DIFF
--- a/src/charmed_kubeflow_chisme/components/pebble_component.py
+++ b/src/charmed_kubeflow_chisme/components/pebble_component.py
@@ -26,7 +26,7 @@ class LazyContainerFileTemplate:
         context: Optional[Union[dict, Callable[[], dict]]] = None,
         user: Optional[str] = None,
         group: Optional[str] = None,
-        permissions: Optional[str] = None,
+        permissions: Optional[int] = None,
     ):
         """A lazy file template renderer for use in pushing files to a Pebble container.
 
@@ -124,7 +124,7 @@ class ContainerFileTemplate(LazyContainerFileTemplate):
         context_function: Optional[Union[dict, Callable[[], dict]]] = None,
         user: Optional[str] = None,
         group: Optional[str] = None,
-        permissions: Optional[str] = None,
+        permissions: Optional[int] = None,
     ):
         """Defines a file template that should be rendered and pushed into a Pebble container.
 

--- a/tests/unit/components/test_pebble_component.py
+++ b/tests/unit/components/test_pebble_component.py
@@ -239,7 +239,7 @@ class TestContainerFileTemplate:
         context = {"key": "value"}
         user = "user"
         group = "group"
-        permissions = "permissions"
+        permissions = 0o777
 
         # Test these without using kwargs to ensure they API doesn't change
         cft = ContainerFileTemplate(
@@ -265,7 +265,7 @@ class TestContainerFileTemplate:
         context = {"key": "value"}
         user = "user"
         group = "group"
-        permissions = "permissions"
+        permissions = 0o777
 
         # Test these without using kwargs to ensure the API doesn't change
         cft = ContainerFileTemplate(
@@ -293,7 +293,7 @@ class TestLazyContainerFileTemplate:
         context = {"key": "value"}
         user = "user"
         group = "group"
-        permissions = "permissions"
+        permissions = 0o777
 
         # Test these without using kwargs to ensure they API doesn't change
         cft = LazyContainerFileTemplate(
@@ -319,7 +319,7 @@ class TestLazyContainerFileTemplate:
         context = {"key": "value"}
         user = "user"
         group = "group"
-        permissions = "permissions"
+        permissions = 0o777
 
         # Test these without using kwargs to ensure they API doesn't change
         cft = LazyContainerFileTemplate(
@@ -345,7 +345,7 @@ class TestLazyContainerFileTemplate:
         context = {"key": "value"}
         user = "user"
         group = "group"
-        permissions = "permissions"
+        permissions = 0o777
 
         # Test these without using kwargs to ensure they API doesn't change
         cft = LazyContainerFileTemplate(
@@ -439,7 +439,7 @@ class TestLazyContainerFileTemplate:
         expected_rendered = "unrendered value template"
         user = "user"
         group = "group"
-        permissions = "permissions"
+        permissions = 0o777
         cft = LazyContainerFileTemplate(
             "destination_path",
             source_template=source_template,


### PR DESCRIPTION
Closes #133 

This is a simple fix that changes the defined type of `permissions` from `str` to `int`. Additionally, the unit tests are updated to reflect this change