### PR TITLE
feat(tests): Add CharmSpec dataclass and helper

### DIFF
--- a/src/charmed_kubeflow_chisme/lightkube/batch/_many.py
+++ b/src/charmed_kubeflow_chisme/lightkube/batch/_many.py
@@ -14,9 +14,13 @@ from ._sort_objects import _sort_objects as sort_objects
 
 LOGGER = logging.getLogger(__name__)
 
-GlobalResourceTypeVar = TypeVar("GlobalResource", bound=resource.GlobalResource)
-GlobalSubResourceTypeVar = TypeVar("GlobalSubResource", bound=resource.GlobalSubResource)
-NamespacedResourceTypeVar = TypeVar("NamespacedSubResource", bound=resource.NamespacedResource)
+GlobalResourceTypeVar = TypeVar("GlobalResource", bound=resource.GlobalResource)  # noqa: N808
+GlobalSubResourceTypeVar = TypeVar(  # noqa: N808
+    "GlobalSubResource", bound=resource.GlobalSubResource
+)
+NamespacedResourceTypeVar = TypeVar(  # noqa: N808
+    "NamespacedSubResource", bound=resource.NamespacedResource
+)
 
 
 def apply_many(

--- a/src/charmed_kubeflow_chisme/testing/README.md
+++ b/src/charmed_kubeflow_chisme/testing/README.md
@@ -5,18 +5,14 @@
 ## CharmSpec
 Dataclass used for defining dependency charms that need to be deployed during tests. This enables modifying those programmatically across all repos, according to each release's values. You can define charms like this:
 ```
-charms = {
-    "minio": CharmSpec(charm="minio", channel="latest/edge", trust=True, config={"access-key": "minio", "secret-key": "minio-secret-key"}),
-    "mysql-k8s": CharmSpec(charm="mysql-k8s", channel="8.0/stable", trust=True, config={"profile": "testing"})
-}
+MINIO = CharmSpec(charm="minio", channel="latest/edge", trust=True, config={"access-key": "minio", "secret-key": "minio-secret-key"})
+MYSQL_K8s = CharmSpec(charm="mysql-k8s", channel="8.0/stable", trust=True, config={"profile": "testing"})
 ```
 
 ## `generate_context_from_charm_spec_dict`
-Function to generate context for rendering a yaml template from dict with CharmSpec objects. This can be used for cases where a bundle.yaml is deployed during tests (e.g. kfp). For example, if Minio is a depending charm:
+Function to generate context for rendering a yaml template from a list of CharmSpec objects. This can be used for cases where a bundle.yaml is deployed during tests (e.g. kfp bundle integration tests). For example, if Minio is a dependency charm:
 ```
-charms = {
-    "minio": CharmSpec(charm="minio", channel="latest/edge", trust=True, config={"access-key": "minio", "secret-key": "minio-secret-key"})
-}
+MINIO = CharmSpec(charm="minio", channel="latest/edge", trust=True, config={"access-key": "minio", "secret-key": "minio-secret-key"})
 ```
 and there is this entry `bundle.yaml.j2` file:
 ```

--- a/src/charmed_kubeflow_chisme/testing/README.md
+++ b/src/charmed_kubeflow_chisme/testing/README.md
@@ -9,7 +9,7 @@ MINIO = CharmSpec(charm="minio", channel="latest/edge", trust=True, config={"acc
 MYSQL_K8s = CharmSpec(charm="mysql-k8s", channel="8.0/stable", trust=True, config={"profile": "testing"})
 ```
 
-## `generate_context_from_charm_spec_dict`
+## `generate_context_from_charm_spec_list`
 Function to generate context for rendering a yaml template from a list of CharmSpec objects. This can be used for cases where a bundle.yaml is deployed during tests (e.g. kfp bundle integration tests). For example, if Minio is a dependency charm:
 ```
 MINIO = CharmSpec(charm="minio", channel="latest/edge", trust=True, config={"access-key": "minio", "secret-key": "minio-secret-key"})
@@ -23,7 +23,7 @@ and there is this entry `bundle.yaml.j2` file:
     scale: 1
     trust: {{ minio_trust }}
 ```
-the `generate_context_from_charm_spec_dict(charms)` will generate all the necessary context.
+the `generate_context_from_charm_spec_list(charms)` will generate all the necessary context, where `charms` is the list of the imported CharmSpec objects.
 
 # COS integration
 

--- a/src/charmed_kubeflow_chisme/testing/README.md
+++ b/src/charmed_kubeflow_chisme/testing/README.md
@@ -1,5 +1,34 @@
 # Chisme testing abstraction
 
+# Charm Spec
+
+## CharmSpec
+Dataclass used for defining charms that need to be deployed during tests. This enables modifying those programmatically across all repos, according to each release's values. You can define charms like this:
+```
+charms = {
+    "minio": CharmSpec(charm="minio", channel="latest/edge", trust=True, config={"access-key": "minio", "secret-key": "minio-secret-key"}),
+    "mysql-k8s": CharmSpec(charm="mysql-k8s", channel="8.0/stable", trust=True, config={"profile": "testing"})
+}
+```
+
+## `generate_context_from_charm_spec_dict`
+Function to generate context for rendering a yaml template from dict with CharmSpec objects. This can be used for cases where a bundle.yaml is deployed during tests (e.g. kfp). For example, if Minio is a depending charm:
+```
+charms = {
+    "minio": CharmSpec(charm="minio", channel="latest/edge", trust=True, config={"access-key": "minio", "secret-key": "minio-secret-key"})
+}
+```
+and there is this entry `bundle.yaml.j2` file:
+```
+  minio:
+    charm: {{ minio_charm }}
+    channel: {{ minio_channel }}
+    base: ubuntu@20.04/stable
+    scale: 1
+    trust: {{ minio_trust }}
+```
+the `generate_context_from_charm_spec_dict(charms)` will generate all the necessary context.
+
 # COS integration
 
 ## `deploy_and_assert_grafana_agent`

--- a/src/charmed_kubeflow_chisme/testing/README.md
+++ b/src/charmed_kubeflow_chisme/testing/README.md
@@ -3,7 +3,7 @@
 # Charm Spec
 
 ## CharmSpec
-Dataclass used for defining charms that need to be deployed during tests. This enables modifying those programmatically across all repos, according to each release's values. You can define charms like this:
+Dataclass used for defining dependency charms that need to be deployed during tests. This enables modifying those programmatically across all repos, according to each release's values. You can define charms like this:
 ```
 charms = {
     "minio": CharmSpec(charm="minio", channel="latest/edge", trust=True, config={"access-key": "minio", "secret-key": "minio-secret-key"}),

--- a/src/charmed_kubeflow_chisme/testing/__init__.py
+++ b/src/charmed_kubeflow_chisme/testing/__init__.py
@@ -2,6 +2,10 @@
 # See LICENSE file for licensing details.
 """Utilities for testing charms."""
 
+from .charm_spec import (
+    CharmSpec,
+    generate_context_from_charm_spec_dict,
+)
 from .cos_integration import (
     ALERT_RULES_DIRECTORY,
     APP_GRAFANA_DASHBOARD,
@@ -27,6 +31,7 @@ from .serialized_data_interface import (
 
 __all__ = [
     RelationMetadata,
+    CharmSpec,
     add_data_to_sdi_relation,
     add_sdi_relation_to_harness,
     assert_alert_rules,
@@ -34,6 +39,7 @@ __all__ = [
     assert_logging,
     assert_metrics_endpoint,
     deploy_and_assert_grafana_agent,
+    generate_context_from_charm_spec_dict,
     get_alert_rules,
     get_grafana_dashboards,
     GRAFANA_AGENT_APP,

--- a/src/charmed_kubeflow_chisme/testing/__init__.py
+++ b/src/charmed_kubeflow_chisme/testing/__init__.py
@@ -2,10 +2,7 @@
 # See LICENSE file for licensing details.
 """Utilities for testing charms."""
 
-from .charm_spec import (
-    CharmSpec,
-    generate_context_from_charm_spec_dict,
-)
+from .charm_spec import CharmSpec, generate_context_from_charm_spec_dict
 from .cos_integration import (
     ALERT_RULES_DIRECTORY,
     APP_GRAFANA_DASHBOARD,

--- a/src/charmed_kubeflow_chisme/testing/__init__.py
+++ b/src/charmed_kubeflow_chisme/testing/__init__.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 """Utilities for testing charms."""
 
-from .charm_spec import CharmSpec, generate_context_from_charm_spec_dict
+from .charm_spec import CharmSpec, generate_context_from_charm_spec_list
 from .cos_integration import (
     ALERT_RULES_DIRECTORY,
     APP_GRAFANA_DASHBOARD,
@@ -36,7 +36,7 @@ __all__ = [
     assert_logging,
     assert_metrics_endpoint,
     deploy_and_assert_grafana_agent,
-    generate_context_from_charm_spec_dict,
+    generate_context_from_charm_spec_list,
     get_alert_rules,
     get_grafana_dashboards,
     GRAFANA_AGENT_APP,

--- a/src/charmed_kubeflow_chisme/testing/charm_spec.py
+++ b/src/charmed_kubeflow_chisme/testing/charm_spec.py
@@ -3,19 +3,20 @@
 """CharmSpec used for defining charms-dependencies during tests."""
 
 from dataclasses import dataclass
-from typing import Dict, Optional, List
+from typing import Dict, List, Optional
 
 
 @dataclass
 class CharmSpec:
     """Dataclass used for defining charms that need to be deployed during tests."""
+
     charm: str
     channel: str
     trust: bool
     config: Optional[Dict] = None
 
     def __post_init__(self):
-        """Simple type validation for class attributes"""
+        """Simple type validation for class attributes."""
         if not isinstance(self.charm, str) or not self.charm:
             raise ValueError("Charm name must be a non-empty string")
 
@@ -28,6 +29,7 @@ class CharmSpec:
         if self.config is not None:
             if not isinstance(self.config, dict):
                 raise ValueError("Config must be a dictionary")
+
 
 def generate_context_from_charm_spec_list(charms: List[CharmSpec]) -> dict:
     """Generate context for rendering a yaml template from a list of CharmSpec objects.

--- a/src/charmed_kubeflow_chisme/testing/charm_spec.py
+++ b/src/charmed_kubeflow_chisme/testing/charm_spec.py
@@ -3,7 +3,7 @@
 """CharmSpec used for defining charms-dependencies during tests."""
 
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 
 @dataclass
@@ -16,28 +16,27 @@ class CharmSpec:
     config: Optional[Dict] = None
 
 
-def generate_context_from_charm_spec_dict(charms_dict: dict) -> dict:
-    """Generate context for rendering a yaml template from dict with CharmSpec objects.
+def generate_context_from_charm_spec_list(charms: List[CharmSpec]) -> dict:
+    """Generate context for rendering a yaml template from a list of CharmSpec objects.
 
     Args:
-        charms_dict: The dictionary containing CharmSpec objects
+        charms: The list containing CharmSpec objects
 
     Returns:
-        Dictionary with keys like {charm_key}_charm, {charm_key}_channel, etc,
+        Dictionary with keys like {charm_name}_charm, {charm_key}_channel, etc,
         ready for template rendering.
     """
     context = {}
-
-    for charm_key, spec in charms_dict.items():
-        # Handle charm names with hyphens convert to underscore for context keys)
-        context_key = charm_key.replace("-", "_")
+    for charm in charms:
+        # Handle charm names with hyphens convert to underscore for context keys
+        context_key = charm.charm.replace("-", "_")
 
         # Add basic fields
-        context[f"{context_key}_charm"] = spec.charm
-        context[f"{context_key}_channel"] = spec.channel
-        context[f"{context_key}_trust"] = spec.trust
+        context[f"{context_key}_charm"] = charm.charm
+        context[f"{context_key}_channel"] = charm.channel
+        context[f"{context_key}_trust"] = charm.trust
 
-        if spec.config:
-            context[f"{context_key}_config"] = spec.config
+        if charm.config:
+            context[f"{context_key}_config"] = charm.config
 
     return context

--- a/src/charmed_kubeflow_chisme/testing/charm_spec.py
+++ b/src/charmed_kubeflow_chisme/testing/charm_spec.py
@@ -13,7 +13,7 @@ class CharmSpec:
     charm: str
     channel: str
     trust: bool
-    config: Optional[Dict]
+    config: Optional[Dict] = None
 
 
 def generate_context_from_charm_spec_dict(charms_dict: dict) -> dict:

--- a/src/charmed_kubeflow_chisme/testing/charm_spec.py
+++ b/src/charmed_kubeflow_chisme/testing/charm_spec.py
@@ -1,35 +1,43 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
 """CharmSpec used for defining charms-dependencies during tests."""
+
 from dataclasses import dataclass
-from typing import Optional, Dict
+from typing import Dict, Optional
+
 
 @dataclass
 class CharmSpec:
+    """Dataclass used for defining charms that need to be deployed during tests."""
+
     charm: str
     channel: str
     trust: bool
     config: Optional[Dict]
 
+
 def generate_context_from_charm_spec_dict(charms_dict: dict) -> dict:
     """Generate context for rendering a yaml template from dict with CharmSpec objects.
-    
+
     Args:
         charms_dict: The dictionary containing CharmSpec objects
-        
+
     Returns:
-        Dictionary with keys like {charm_key}_charm, {charm_key}_channel, etc, ready for template rendering.
+        Dictionary with keys like {charm_key}_charm, {charm_key}_channel, etc,
+        ready for template rendering.
     """
     context = {}
-    
+
     for charm_key, spec in charms_dict.items():
         # Handle charm names with hyphens convert to underscore for context keys)
-        context_key = charm_key.replace('-', '_')
-        
+        context_key = charm_key.replace("-", "_")
+
         # Add basic fields
         context[f"{context_key}_charm"] = spec.charm
         context[f"{context_key}_channel"] = spec.channel
         context[f"{context_key}_trust"] = spec.trust
-        
+
         if spec.config:
             context[f"{context_key}_config"] = spec.config
-    
+
     return context

--- a/src/charmed_kubeflow_chisme/testing/charm_spec.py
+++ b/src/charmed_kubeflow_chisme/testing/charm_spec.py
@@ -9,12 +9,25 @@ from typing import Dict, Optional, List
 @dataclass
 class CharmSpec:
     """Dataclass used for defining charms that need to be deployed during tests."""
-
     charm: str
     channel: str
     trust: bool
     config: Optional[Dict] = None
 
+    def __post_init__(self):
+        """Simple type validation for class attributes"""
+        if not isinstance(self.charm, str) or not self.charm:
+            raise ValueError("Charm name must be a non-empty string")
+
+        if not isinstance(self.channel, str) or "/" not in self.channel:
+            raise ValueError("Channel must be in format 'track/risk'")
+
+        if not isinstance(self.trust, bool):
+            raise ValueError("Trust must be a boolean value")
+
+        if self.config is not None:
+            if not isinstance(self.config, dict):
+                raise ValueError("Config must be a dictionary")
 
 def generate_context_from_charm_spec_list(charms: List[CharmSpec]) -> dict:
     """Generate context for rendering a yaml template from a list of CharmSpec objects.

--- a/src/charmed_kubeflow_chisme/testing/charm_spec.py
+++ b/src/charmed_kubeflow_chisme/testing/charm_spec.py
@@ -1,0 +1,35 @@
+"""CharmSpec used for defining charms-dependencies during tests."""
+from dataclasses import dataclass
+from typing import Optional, Dict
+
+@dataclass
+class CharmSpec:
+    charm: str
+    channel: str
+    trust: bool
+    config: Optional[Dict]
+
+def generate_context_from_charm_spec_dict(charms_dict: dict) -> dict:
+    """Generate context for rendering a yaml template from dict with CharmSpec objects.
+    
+    Args:
+        charms_dict: The dictionary containing CharmSpec objects
+        
+    Returns:
+        Dictionary with keys like {charm_key}_charm, {charm_key}_channel, etc, ready for template rendering.
+    """
+    context = {}
+    
+    for charm_key, spec in charms_dict.items():
+        # Handle charm names with hyphens convert to underscore for context keys)
+        context_key = charm_key.replace('-', '_')
+        
+        # Add basic fields
+        context[f"{context_key}_charm"] = spec.charm
+        context[f"{context_key}_channel"] = spec.channel
+        context[f"{context_key}_trust"] = spec.trust
+        
+        if spec.config:
+            context[f"{context_key}_config"] = spec.config
+    
+    return context


### PR DESCRIPTION
* Add CharmSpec data class to enable defining charms that need to be
  deployed during tests.
* Add generate_context_from_charm_spec_dict() to extracting context from
  a dict with CharmSpec objects, in order to render bundle.yaml.j2
  files.

Ref canonical/bundle-kubeflow/issues/1256

#### Testing
Tests fail due to #139, which will be addressed separately.
