### PR TITLE
chore: bump version to 0.4.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = charmed-kubeflow-chisme
-version = 0.4.6
+version = 0.4.7
 author = Charmed Kubeflow
 description = A collection of helpers for Charms maintained by the Charmed Kubeflow team
 long_description = file: README.md


### PR DESCRIPTION
Release 0.4.7 with changes from
* #138 (f3009cc9dd05e5e1f3c97bb769e7f2846ca22dee)

WRT effort in canonical/bundle-kubeflow#1256.