### PR TITLE
chore: bump version to 0.4.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = charmed-kubeflow-chisme
-version = 0.4.8
+version = 0.4.9
 author = Charmed Kubeflow
 description = A collection of helpers for Charms maintained by the Charmed Kubeflow team
 long_description = file: README.md


### PR DESCRIPTION
Release 0.4.9 since 0.4.8 and 0.4.7 failed to be released
due to CI issues. The CI should have been fixed in #146
