### PR TITLE
fix: Update default channel for observability charms

### DIFF
--- a/src/charmed_kubeflow_chisme/testing/cos_integration.py
+++ b/src/charmed_kubeflow_chisme/testing/cos_integration.py
@@ -51,7 +51,7 @@ REQUIRES = "requires"
 async def deploy_and_assert_grafana_agent(
     model: Model,
     app: str,
-    channel: str = "latest/stable",
+    channel: str = "1/stable",
     metrics: bool = False,
     logging: bool = False,
     dashboard: bool = False,
@@ -64,7 +64,7 @@ async def deploy_and_assert_grafana_agent(
     Args:
         model (juju.model.Model): Juju model object.
         app (str): Name of application with which the Grafana agent should be related.
-        channel (str): Channel name for grafana-agent-k8s. Defaults to latest/stable.
+        channel (str): Channel name for grafana-agent-k8s. Defaults to 1/stable.
         metrics (bool): Boolean that defines if the <app>:metrics-endpoint
             grafana-agent-k8s:metrics-endpoint relation is created. Defaults to False.
         logging (bool): Boolean that defines if the <app>:logging

--- a/tests/integration/test_cos.py
+++ b/tests/integration/test_cos.py
@@ -22,7 +22,7 @@ from charmed_kubeflow_chisme.testing import (
 # 'metrics-endpoint'.
 charmed_kubeflow_chisme.testing.cos_integration.APP_METRICS_ENDPOINT = "self-metrics-endpoint"
 TESTED_APP = "blackbox-exporter-k8s"
-TESTED_APP_CHANNEL = "latest/stable"
+TESTED_APP_CHANNEL = "1/stable"
 
 
 @pytest.mark.abort_on_fail
@@ -74,7 +74,7 @@ def fetch_alert_rules_from_downloaded_charm(charm: str):
 
         # Download charm under temp_dir
         try:
-            # With `--channel latest/stable`, Juju CLI returns error even when the channel exists.
+            # With `--channel 1/stable`, Juju CLI returns error even when the channel exists.
             sh.juju.download(
                 charm,
                 "--channel",

--- a/tests/unit/testing/test_cos.py
+++ b/tests/unit/testing/test_cos.py
@@ -193,7 +193,7 @@ async def test_deploy_and_assert_grafana_agent(kwargs, exp_awaits):
 
     await deploy_and_assert_grafana_agent(model, app.name, **kwargs)
 
-    model.deploy.assert_awaited_once_with("grafana-agent-k8s", channel="latest/stable")
+    model.deploy.assert_awaited_once_with("grafana-agent-k8s", channel="1/stable")
     model.integrate.assert_has_awaits(exp_awaits)
     model.wait_for_idle.assert_awaited_once_with(
         apps=["grafana-agent-k8s"], status="blocked", timeout=300, idle_period=60


### PR DESCRIPTION
Reference issue: #155

This PR simply updates the default channel for all observability charms to "1/stable", since `latest/stable` has been deprecated. This includes:
- `grafana-agents-k8s` in `deploy_and_assert_grafana_agent()`
- `blackbox-exporter-k8s` in `tests/integration/test_cos.py`