### PR TITLE
chore: bump version to 0.4.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = charmed-kubeflow-chisme
-version = 0.4.12
+version = 0.4.13
 author = Charmed Kubeflow
 description = A collection of helpers for Charms maintained by the Charmed Kubeflow team
 long_description = file: README.md


### PR DESCRIPTION
Includes the following new utilities:
* https://github.com/canonical/charmed-kubeflow-chisme/pull/163