### PR TITLE
fix: set `wait_for_active` to `True` in ambient test util

### DIFF
--- a/src/charmed_kubeflow_chisme/testing/ambient_integration.py
+++ b/src/charmed_kubeflow_chisme/testing/ambient_integration.py
@@ -102,6 +102,7 @@ async def integrate_with_service_mesh(
     await model.wait_for_idle(
         raise_on_blocked=False,
         raise_on_error=True,
+        wait_for_active=True,
         timeout=900,
     )
 

--- a/tests/unit/testing/test_ambient_integration.py
+++ b/tests/unit/testing/test_ambient_integration.py
@@ -50,8 +50,13 @@ async def test_deploy_and_integrate_service_mesh_charms():
         f"{ISTIO_BEACON_K8S_APP}:{SERVICE_MESH_ENDPOINT}", f"{app_name}:{SERVICE_MESH_ENDPOINT}"
     )
 
-    # Verify wait for idle
-    model.wait_for_idle.assert_awaited_once()
+    # Verify wait for idle with correct parameters
+    model.wait_for_idle.assert_awaited_once_with(
+        raise_on_blocked=False,
+        raise_on_error=True,
+        wait_for_active=True,
+        timeout=900,
+    )
 
 
 @pytest.mark.asyncio
@@ -80,7 +85,13 @@ async def test_integrate_with_service_mesh():
         f"{app_name}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
     )
 
-    model.wait_for_idle.assert_awaited_once()
+    # Verify wait for idle with correct parameters
+    model.wait_for_idle.assert_awaited_once_with(
+        raise_on_blocked=False,
+        raise_on_error=True,
+        wait_for_active=True,
+        timeout=900,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Following up the changes made in #164, the `integrate_with_service_mesh` function is waiting for charms in the model to be `idle` but that doesn't necessarily mean they are `active`. 

I've seen a failure due to this [in this run](https://github.com/canonical/katib-operators/actions/runs/19903370004/job/57054212861). Notice that `istio-ingress-k8s` is `idle` but the status is `maintenance`.

This PR sets `wait_for_active` to `True`  to avoid such intermittent failures.

Note that after merging this, a new chisme version should be released and the chisme version updated in relevant repos.