### PR TITLE
fix: don't raise on error for Ambient charms

### DIFF
--- a/src/charmed_kubeflow_chisme/testing/ambient_integration.py
+++ b/src/charmed_kubeflow_chisme/testing/ambient_integration.py
@@ -104,7 +104,15 @@ async def integrate_with_service_mesh(
         )
 
     await model.wait_for_idle(
-        [app, ISTIO_BEACON_K8S_APP, ISTIO_INGRESS_K8S_APP, ISTIO_K8S_APP],
+        [ISTIO_BEACON_K8S_APP, ISTIO_INGRESS_K8S_APP, ISTIO_K8S_APP],
+        raise_on_blocked=False,
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=900,
+    )
+
+    await model.wait_for_idle(
+        [app],
         raise_on_blocked=False,
         raise_on_error=True,
         wait_for_active=True,

--- a/tests/unit/testing/test_ambient_integration.py
+++ b/tests/unit/testing/test_ambient_integration.py
@@ -60,14 +60,8 @@ async def test_deploy_and_integrate_service_mesh_charms():
         f"{app_name}:{SERVICE_MESH_ENDPOINT}",
     )
 
-    # Verify wait for idle with correct parameters
-    model.wait_for_idle.assert_awaited_once_with(
-        [app_name, ISTIO_BEACON_K8S_APP, ISTIO_INGRESS_K8S_APP, ISTIO_K8S_APP],
-        raise_on_blocked=False,
-        raise_on_error=True,
-        wait_for_active=True,
-        timeout=900,
-    )
+    # Verify wait for idle
+    assert model.wait_for_idle.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -96,14 +90,8 @@ async def test_integrate_with_service_mesh():
         f"{app_name}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
     )
 
-    # Verify wait for idle with correct parameters
-    model.wait_for_idle.assert_awaited_once_with(
-        [app_name, ISTIO_BEACON_K8S_APP, ISTIO_INGRESS_K8S_APP, ISTIO_K8S_APP],
-        raise_on_blocked=False,
-        raise_on_error=True,
-        wait_for_active=True,
-        timeout=900,
-    )
+    # Verify wait for idle
+    assert model.wait_for_idle.call_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Handles https://github.com/canonical/kubeflow-dashboard-operator/pull/304#issuecomment-3625846446

## Changes
1. Wait separately for Ambient mesh charms and the related app to become active
2. When waiting for ambient charms, don't `rase_on_error`