### PR TITLE
chore: bump to 0.4.18

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = charmed-kubeflow-chisme
-version = 0.4.17
+version = 0.4.18
 author = Charmed Kubeflow
 description = A collection of helpers for Charms maintained by the Charmed Kubeflow team
 long_description = file: README.md


### PR DESCRIPTION
To include the changes from https://github.com/canonical/charmed-kubeflow-chisme/pull/175