### PR TITLE
feat: apply ambient charms sequentially

### DIFF
--- a/src/charmed_kubeflow_chisme/testing/ambient_integration.py
+++ b/src/charmed_kubeflow_chisme/testing/ambient_integration.py
@@ -45,10 +45,26 @@ async def deploy_and_integrate_service_mesh_charms(
         trust=True,
     )
 
+    await model.wait_for_idle(
+        [ISTIO_K8S_APP],
+        raise_on_blocked=False,
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=900,
+    )
+
     await model.deploy(
         ISTIO_INGRESS_K8S_APP,
         channel=channel,
         trust=True,
+    )
+
+    await model.wait_for_idle(
+        [ISTIO_INGRESS_K8S_APP],
+        raise_on_blocked=False,
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=900,
     )
 
     await model.deploy(
@@ -56,6 +72,14 @@ async def deploy_and_integrate_service_mesh_charms(
         channel=channel,
         trust=True,
         config={"model-on-mesh": model_on_mesh},
+    )
+
+    await model.wait_for_idle(
+        [ISTIO_BEACON_K8S_APP],
+        raise_on_blocked=False,
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=900,
     )
 
     await integrate_with_service_mesh(

--- a/tests/unit/testing/test_ambient_integration.py
+++ b/tests/unit/testing/test_ambient_integration.py
@@ -61,7 +61,7 @@ async def test_deploy_and_integrate_service_mesh_charms():
     )
 
     # Verify wait for idle
-    assert model.wait_for_idle.call_count == 2
+    assert model.wait_for_idle.call_count == 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR was inspired by the flakiness we've seen in a lot of PRs (i.e. https://github.com/canonical/envoy-operator/pull/188, https://github.com/canonical/kubeflow-tensorboards-operator/pull/221) in which the tests were failing on the `build_and_deploy` step.

A lot of the times the culprit was the Istio charms, in which they were getting to error state and then taking a lot of time to recover.

This PR aims to resolve this by installing, and waiting for idle, the Istio ambient charms **sequentially**. So:
1. First the `istio-k8s` charm should be active
2. Then the `istio-ingress-k8s`
3. Then the `istio-beacon-k8s`, which also adds the model to the namespace