### PR TITLE
chore: bump version to 0.4.25

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = charmed-kubeflow-chisme
-version = 0.4.24
+version = 0.4.25
 author = Charmed Kubeflow
 description = A collection of helpers for Charms maintained by the Charmed Kubeflow team
 long_description = file: README.md


### PR DESCRIPTION
Addressing https://github.com/canonical/charmed-kubeflow-chisme/pull/194#issuecomment-4135278488 to include changes from https://github.com/canonical/charmed-kubeflow-chisme/pull/194 while also including https://github.com/canonical/charmed-kubeflow-chisme/pull/195. 