### PR TITLE
fix: add permissions and update checkout in gh-release workflow

### DIFF
--- a/.github/workflows/gh-release.yaml
+++ b/.github/workflows/gh-release.yaml
@@ -14,9 +14,13 @@ jobs:
     name: "Tagged Release"
     runs-on: "ubuntu-22.04"
     needs: tests
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

The previous PR which created a new release [did not succeed creating the release](https://github.com/canonical/charmed-kubeflow-chisme/actions/runs/27701446746/job/81940370337).

- Add `contents: write` permission to the `tagged-release` job so `GITHUB_TOKEN` can create releases
- Update `actions/checkout` from `v3` to `v6` with `persist-credentials: false`

Fixes the `Resource not accessible by integration` error seen in https://github.com/canonical/charmed-kubeflow-chisme/actions/runs/27701446746/job/81940370337

We should also probably update the unmaintained `marvinpinto/action-automatic-releases` action, but we should do it in another PR.