### PR TITLE
chore: Bump version to `0.4.27`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = charmed-kubeflow-chisme
-version = 0.4.26
+version = 0.4.27
 author = Charmed Kubeflow
 description = A collection of helpers for Charms maintained by the Charmed Kubeflow team
 long_description = file: README.md


### PR DESCRIPTION
Creating a new release, since the failed "release" action is being re-triggered with the old workflow file, see https://github.com/canonical/charmed-kubeflow-chisme/actions/runs/27701446746/job/82081502471#step:3:10