### PR TITLE
fix: export s3_integration helpers from testing package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = charmed-kubeflow-chisme
-version = 0.4.27
+version = 0.4.28
 author = Charmed Kubeflow
 description = A collection of helpers for Charms maintained by the Charmed Kubeflow team
 long_description = file: README.md

--- a/src/charmed_kubeflow_chisme/testing/__init__.py
+++ b/src/charmed_kubeflow_chisme/testing/__init__.py
@@ -37,6 +37,19 @@ from .cos_integration import (
     get_alert_rules,
     get_grafana_dashboards,
 )
+from .s3_integration import (
+    SECRET_LABEL,
+    S3ConnectionInfo,
+    certs_path,
+    create_root_user,
+    deploy_and_assert_s3_integrator,
+    host_ip,
+    install_microceph,
+    local_tmp_folder,
+    setup_microceph,
+    setup_radosgw,
+    wait_for_rgw_ready,
+)
 from .serialized_data_interface import (
     RelationMetadata,
     add_data_to_sdi_relation,
@@ -77,4 +90,15 @@ __all__ = [
     integrate_with_service_mesh,
     get_http_response,
     assert_path_reachable_through_ingress,
+    S3ConnectionInfo,
+    SECRET_LABEL,
+    certs_path,
+    create_root_user,
+    deploy_and_assert_s3_integrator,
+    host_ip,
+    install_microceph,
+    local_tmp_folder,
+    setup_microceph,
+    setup_radosgw,
+    wait_for_rgw_ready,
 ]


### PR DESCRIPTION
## Summary

- `s3_integration.py` was added in #199 but its public symbols were never wired into `testing/__init__.py`, making them inaccessible via `from charmed_kubeflow_chisme.testing import ...`
- Adds imports and `__all__` entries for all 11 public symbols, similarly to how we do for the other testing modules